### PR TITLE
Fix for whitespace in descendant elements of <pre>

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -467,6 +467,10 @@
           output = '<pre title="some title...">   hello     world </pre>';
           equals(minify(input, { collapseWhitespace: true }), output);
           
+          input = '<pre title="some title..."><code>   hello     world </code></pre>';
+          output = '<pre title="some title..."><code>   hello     world </code></pre>';
+          equals(minify(input, { collapseWhitespace: true }), output);
+          
           input = '<script>alert("foo     bar")    <\/script>';
           output = '<script>alert("foo     bar")<\/script>';
           equals(minify(input, { collapseWhitespace: true }), output);


### PR DESCRIPTION
Hi Juriy,

Love this tool, I'm using it to import snippets of HTML into a JSON file where minification helps a lot.
I've just run into the bug with a <pre><code> tag combination stripping whitespace, and wrote a quick fix to get by.

Cheers,

Gil
