### PR TITLE
npmignore unneeded files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+dist
+tests
+v8
+.travis.yml
+index.html
+master.css
+master.js
+test.js


### PR DESCRIPTION
No need to waste bandwidth and space. This would make this module about 0.5MB smaller.
