### PR TITLE
HTML5 flow elements, as well as a re-built all.js

### DIFF
--- a/dist/all.js
+++ b/dist/all.js
@@ -163,8 +163,10 @@
 
     function parseStartTag( tag, tagName, rest, unary ) {
       if ( block[ tagName ] ) {
-        while ( stack.last() && inline[ stack.last() ] && !flow[ stack.last() ]) {
-          parseEndTag( "", stack.last() );
+        if ( !handler.html5 || !flow[ stack.last() ] ) {
+          while ( stack.last() && inline[ stack.last() ]) {
+            parseEndTag( "", stack.last() );
+          }
         }
       }
 
@@ -386,26 +388,26 @@
   function collapseWhitespace(str) {
     return str.replace(/\s+/g, ' ');
   }
-  
+
   function collapseWhitespaceSmart(str, prevTag, nextTag) {
     // array of tags that will maintain a single space outside of them
     var tags = ['a', 'b', 'big', 'button', 'em', 'font','i',  'img', 'mark', 's', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'tt', 'u'];
-    
+
     if (prevTag && (prevTag.substr(0,1) !== '/'
-      || ( prevTag.substr(0,1) === '/' && tags.indexOf(prevTag.substr(1)) === -1))) {
-      str = str.replace(/^\s+/, '');
+        || ( prevTag.substr(0,1) === '/' && tags.indexOf(prevTag.substr(1)) === -1))) {
+        str = str.replace(/^\s+/, '');
     }
-    
+
     if (nextTag && (nextTag.substr(0,1) === '/'
-      || ( nextTag.substr(0,1) !== '/' && tags.indexOf(nextTag) === -1))) {
-      str = str.replace(/\s+$/, '');
-    } 
-    
-    if (prevTag && nextTag) {
-      // strip non space whitespace then compress spaces to one
-      return str.replace(/[\t\n\r]+/g, '').replace(/[ ]+/g, ' ');
+        || ( nextTag.substr(0,1) !== '/' && tags.indexOf(nextTag) === -1))) {
+        str = str.replace(/\s+$/, '');
     }
-    
+
+    if (prevTag && nextTag) {
+        // strip non space whitespace then compress spaces to one
+        return str.replace(/[\t\n\r]+/g, '').replace(/[ ]+/g, ' ');
+    }
+
     return str;
   }
 
@@ -660,6 +662,8 @@
     }
 
     HTMLParser(value, {
+      html5: options.html5,
+
       start: function( tag, attrs ) {
         tag = tag.toLowerCase();
         currentTag = tag;
@@ -773,6 +777,7 @@
   }
 
 }(this));
+
 /*!
  * HTMLLint (to be used in conjunction with HTMLMinifier)
  *

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -39,26 +39,26 @@
   function collapseWhitespace(str) {
     return str.replace(/\s+/g, ' ');
   }
-  
+
   function collapseWhitespaceSmart(str, prevTag, nextTag) {
   	// array of tags that will maintain a single space outside of them
   	var tags = ['a', 'b', 'big', 'button', 'em', 'font','i',  'img', 'mark', 's', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'tt', 'u'];
-  	
+
   	if (prevTag && (prevTag.substr(0,1) !== '/'
   		|| ( prevTag.substr(0,1) === '/' && tags.indexOf(prevTag.substr(1)) === -1))) {
 	  	str = str.replace(/^\s+/, '');
   	}
-  	
+
   	if (nextTag && (nextTag.substr(0,1) === '/'
   		|| ( nextTag.substr(0,1) !== '/' && tags.indexOf(nextTag) === -1))) {
   		str = str.replace(/\s+$/, '');
-  	} 
-  	
+  	}
+
   	if (prevTag && nextTag) {
   		// strip non space whitespace then compress spaces to one
 	  	return str.replace(/[\t\n\r]+/g, '').replace(/[ ]+/g, ' ');
   	}
-  	
+
     return str;
   }
 
@@ -313,6 +313,8 @@
     }
 
     HTMLParser(value, {
+      html5: options.html5,
+
       start: function( tag, attrs ) {
         tag = tag.toLowerCase();
         currentTag = tag;

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -163,8 +163,10 @@
 
     function parseStartTag( tag, tagName, rest, unary ) {
       if ( block[ tagName ] ) {
-        while ( stack.last() && inline[ stack.last() ] && !flow[ stack.last() ]) {
-          parseEndTag( "", stack.last() );
+        if ( !handler.html5 || !flow[ stack.last() ] ) {
+          while ( stack.last() && inline[ stack.last() ]) {
+            parseEndTag( "", stack.last() );
+          }
         }
       }
 

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -31,15 +31,18 @@
       endTag = /^<\/(\w+)[^>]*>/,
       attr = /([\w:-]+)(?:\s*=\s*(?:(?:"((?:\\.|[^"])*)")|(?:'((?:\\.|[^'])*)')|([^>\s]+)))?/g,
       doctype = /^<!DOCTYPE [^>]+>/i;
-    
+
   // Empty Elements - HTML 4.01
   var empty = makeMap("area,base,basefont,br,col,frame,hr,img,input,isindex,link,meta,param,embed");
 
-  // Block Elements - HTML 4.01
-  var block = makeMap("address,applet,blockquote,button,center,dd,del,dir,div,dl,dt,fieldset,form,frameset,hr,iframe,ins,isindex,li,map,menu,noframes,noscript,object,ol,p,pre,script,table,tbody,td,tfoot,th,thead,tr,ul");
+  // Block Elements
+  var block = makeMap("address,applet,article,aside,audio,blockquote,button,canvas,center,dd,del,dir,div,dl,dt,fieldset,figcaption,figure,footer,form,frameset,header,hgroup,hr,iframe,ins,isindex,li,map,menu,noframes,noscript,ol,output,p,pre,section,script,table,tbody,td,tfoot,th,thead,tr,ul,video");
 
-  // Inline Elements - HTML 4.01
-  var inline = makeMap("a,abbr,acronym,applet,b,basefont,bdo,big,br,button,cite,code,del,dfn,em,font,i,iframe,img,input,ins,kbd,label,map,object,q,s,samp,script,select,small,span,strike,strong,sub,sup,textarea,tt,u,var");
+  // Inline Elements
+  var inline = makeMap("a,abbr,acronym,applet,b,basefont,bdo,big,br,button,cite,code,command,datalist,del,details,dfn,em,font,i,iframe,img,input,ins,kbd,label,map,mark,meter,nav,object,q,s,samp,script,select,small,source,span,strike,strong,sub,summary,sup,textarea,time,tt,u,var");
+
+  // Flow Elements which can contain block elements
+  var flow = makeMap("a,abbr,address,article,aside,audio,b,bdo,blockquote,br,button,canvas,cite,code,command,datalist,del,details,dfn,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,keygen,label,map,mark,math,menu,meter,nav,noscript,object,ol,output,p,pre,progress,q,ruby,samp,script,section,select,small,span,strong,sub,sup,svg,table,textarea,time,ul,var,video,wbr");
 
   // Elements that you can, intentionally, leave open
   // (and which close themselves)
@@ -50,7 +53,7 @@
 
   // Special Elements (can contain anything)
   var special = makeMap("script,style");
-  
+
   var reCache = { }, stackedTag, re;
 
   var HTMLParser = global.HTMLParser = function( html, handler ) {
@@ -68,7 +71,7 @@
         // Comment
         if ( html.indexOf("<!--") === 0 ) {
           index = html.indexOf("-->");
-  
+
           if ( index >= 0 ) {
             if ( handler.comment )
               handler.comment( html.substring( 4, index ) );
@@ -81,22 +84,22 @@
             handler.doctype( match[0] );
           html = html.substring( match[0].length );
           chars = false;
-        
+
         // end tag
         } else if ( html.indexOf("</") === 0 ) {
           match = html.match( endTag );
-  
+
           if ( match ) {
             html = html.substring( match[0].length );
             match[0].replace( endTag, parseEndTag );
             prevTag = '/'+match[1];
             chars = false;
           }
-  
+
         // start tag
         } else if ( html.indexOf("<") === 0 ) {
           match = html.match( startTag );
-  
+
           if ( match ) {
             html = html.substring( match[0].length );
             match[0].replace( startTag, parseStartTag );
@@ -107,33 +110,33 @@
 
         if ( chars ) {
           index = html.indexOf("<");
-          
+
           var text = index < 0 ? html : html.substring( 0, index );
           html = index < 0 ? "" : html.substring( index );
-          
+
           // next tag
           tagMatch = html.match( startTag );
           if (tagMatch) {
-	        nextTag = tagMatch[1];
+            nextTag = tagMatch[1];
           } else {
-	        tagMatch = html.match( endTag );
-	        if (tagMatch) {
-	          nextTag = '/'+tagMatch[1];
-	        } else {
-		      nextTag = '';
-	        }
+            tagMatch = html.match( endTag );
+            if (tagMatch) {
+              nextTag = '/'+tagMatch[1];
+            } else {
+            nextTag = '';
+            }
           }
-          
+
           if ( handler.chars )
-	        handler.chars(text, prevTag, nextTag);
-          
+            handler.chars(text, prevTag, nextTag);
+
         }
 
       } else {
-        
+
         stackedTag = stack.last().toLowerCase();
         reStackedTag = reCache[stackedTag] || (reCache[stackedTag] = new RegExp("([\\s\\S]*?)<\/" + stackedTag + "[^>]*>", "i"));
-        
+
         html = html.replace(reStackedTag, function(all, text) {
           if (stackedTag !== 'script' && stackedTag !== 'style') {
             text = text
@@ -154,13 +157,13 @@
         throw "Parse Error: " + html;
       last = html;
     }
-    
+
     // Clean up any remaining tags
     parseEndTag();
 
     function parseStartTag( tag, tagName, rest, unary ) {
       if ( block[ tagName ] ) {
-        while ( stack.last() && inline[ stack.last() ] ) {
+        while ( stack.last() && inline[ stack.last() ] && !flow[ stack.last() ]) {
           parseEndTag( "", stack.last() );
         }
       }
@@ -173,10 +176,10 @@
 
       if ( !unary )
         stack.push( tagName );
-      
+
       if ( handler.start ) {
         var attrs = [];
-  
+
         rest.replace(attr, function(match, name) {
           var value = arguments[2] ? arguments[2] :
             arguments[3] ? arguments[3] :
@@ -188,7 +191,7 @@
             escaped: value.replace(/(^|[^\\])"/g, '$1\\\"') //"
           });
         });
-  
+
         if ( handler.start )
           handler.start( tagName, attrs, unary );
       }
@@ -198,35 +201,35 @@
       // If no tag name is provided, clean shop
       if ( !tagName )
         var pos = 0;
-        
+
       // Find the closest opened tag of the same type
       else
         for ( var pos = stack.length - 1; pos >= 0; pos-- )
           if ( stack[ pos ] == tagName )
             break;
-      
+
       if ( pos >= 0 ) {
         // Close all the open elements, up the stack
         for ( var i = stack.length - 1; i >= pos; i-- )
           if ( handler.end )
             handler.end( stack[ i ] );
-        
+
         // Remove the open elements from the stack
         stack.length = pos;
       }
     }
   };
-  
+
   global.HTMLtoXML = function( html ) {
     var results = "";
-    
+
     HTMLParser(html, {
       start: function( tag, attrs, unary ) {
         results += "<" + tag;
-    
+
         for ( var i = 0; i < attrs.length; i++ )
           results += " " + attrs[i].name + '="' + attrs[i].escaped + '"';
-    
+
         results += (unary ? "/" : "") + ">";
       },
       end: function( tag ) {
@@ -239,20 +242,20 @@
         results += "<!--" + text + "-->";
       }
     });
-    
+
     return results;
   };
-  
+
   global.HTMLtoDOM = function( html, doc ) {
     // There can be only one of these elements
     var one = makeMap("html,head,body,title");
-    
+
     // Enforce a structure for the document
     var structure = {
       link: "head",
       base: "head"
     };
-  
+
     if ( !doc ) {
       if ( typeof DOMDocument != "undefined" )
         doc = new DOMDocument();
@@ -260,16 +263,16 @@
         doc = document.implementation.createDocument("", "", null);
       else if ( typeof ActiveX != "undefined" )
         doc = new ActiveXObject("Msxml.DOMDocument");
-      
+
     } else
       doc = doc.ownerDocument ||
         doc.getOwnerDocument && doc.getOwnerDocument() ||
         doc;
-    
+
     var elems = [],
       documentElement = doc.documentElement ||
         doc.getDocumentElement && doc.getDocumentElement();
-        
+
     // If we're dealing with an empty document then we
     // need to pre-populate it with the HTML document structure
     if ( !documentElement && doc.createElement ) (function(){
@@ -280,16 +283,16 @@
       html.appendChild( doc.createElement("body") );
       doc.appendChild( html );
     })();
-    
+
     // Find all the unique elements
     if ( doc.getElementsByTagName )
       for ( var i in one )
         one[ i ] = doc.getElementsByTagName( i )[0];
-    
+
     // If we're working with a document, inject contents into
     // the body element
     var curParentNode = one.body;
-    
+
     HTMLParser( html, {
       start: function( tagName, attrs, unary ) {
         // If it's a pre-built element, then we can ignore
@@ -298,18 +301,18 @@
           curParentNode = one[ tagName ];
           return;
         }
-      
+
         var elem = doc.createElement( tagName );
-        
+
         for ( var attr in attrs )
           elem.setAttribute( attrs[ attr ].name, attrs[ attr ].value );
-        
+
         if ( structure[ tagName ] && typeof one[ structure[ tagName ] ] != "boolean" )
           one[ structure[ tagName ] ].appendChild( elem );
-        
+
         else if ( curParentNode && curParentNode.appendChild )
           curParentNode.appendChild( elem );
-          
+
         if ( !unary ) {
           elems.push( elem );
           curParentNode = elem;
@@ -317,7 +320,7 @@
       },
       end: function( tag ) {
         elems.length -= 1;
-        
+
         // Init the new parentNode
         curParentNode = elems[ elems.length - 1 ];
       },
@@ -328,7 +331,7 @@
         // create comment node
       }
     });
-    
+
     return doc;
   };
 

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -436,7 +436,7 @@
     input = '<p> foo    bar</p>';
     output = '<p>foo bar</p>';
     equal(minify(input, { collapseWhitespace: true }), output);
-    
+
     input = '<p> foo    <span>  blah     <i>   22</i>    </span> bar <img src=""></p>';
     output = '<p>foo <span>blah <i>22</i></span> bar <img src=""></p>';
     equal(minify(input, { collapseWhitespace: true }), output);
@@ -573,7 +573,7 @@
     input = '<a href="#"><div>Well, look at me! I\'m a div!</div></a>';
     output = '<a href="#"><div>Well, look at me! I\'m a div!</div></a>';
 
-    equal(minify(input), output);
+    equal(minify(input, { html5: true }), output);
   });
 
   test('HTML5: anchor with mixed inline and block elements', function(){
@@ -595,7 +595,7 @@
               '</section>' +
             '</a>';
 
-    equal(minify(input), output);
+    equal(minify(input, { html5: true }), output);
   });
 
 })(typeof exports === 'undefined' ? window : exports);

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -562,4 +562,40 @@
     equal(minify(input, { removeOptionalTags: true }), output);
   });
 
+  test('custom components', function(){
+    input = '<custom-component>Oh, my.</custom-component>';
+    output = '<custom-component>Oh, my.</custom-component>';
+
+    equal(minify(input), output);
+  });
+
+  test('HTML5: anchor with block elements', function(){
+    input = '<a href="#"><div>Well, look at me! I\'m a div!</div></a>';
+    output = '<a href="#"><div>Well, look at me! I\'m a div!</div></a>';
+
+    equal(minify(input), output);
+  });
+
+  test('HTML5: anchor with mixed inline and block elements', function(){
+    input = '<a href="#">' +
+              '<section>' +
+                '<h1>Shoes for Puppies</h1>' +
+                '<p>' +
+                  'Only the finest pupwear, for irresistible prices!' +
+                '</p>' +
+              '</section>' +
+            '</a>';
+
+    output = '<a href="#">' +
+              '<section>' +
+                '<h1>Shoes for Puppies</h1>' +
+                '<p>' +
+                  'Only the finest pupwear, for irresistible prices!' +
+                '</p>' +
+              '</section>' +
+            '</a>';
+
+    equal(minify(input), output);
+  });
+
 })(typeof exports === 'undefined' ? window : exports);


### PR DESCRIPTION
Hey,

I took a stab at a couple things real quick. Not sure if this is "master-ready," but it didn't break any tests :+1: 

First of all, I was stumped why the tests I was running through the terminal were throwing errors that the browser test runner weren't. I tracked that down to `dist/all.js`, which seems to have been out of date with the source files. I didn't see a build process for generating/concatenating all.js, so I just copy and pasted in its parts, and voila, it worked.

Once I got that figured out, I created a new map in the parser for [HTML5 flow elements](https://developer.mozilla.org/en-US/docs/HTML/Content_categories#Flow_content), and updated the code to not pressure these elements to have only one type of content within them.

I added a couple tests for these flow elements, as well as a test for custom components, which seem to be working now that all.js is updated.

Let me know what you think. I'm happy to make adjustments or discuss further the best way to proceed with supporting these new flow elements and custom components.

[#46, https://github.com/yeoman/yeoman/issues/1010, https://github.com/yeoman/grunt-usemin/issues/87]
