### PR TITLE
Allow hyphens to work in tag names

### DIFF
--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -28,7 +28,7 @@
 
   // Regular Expressions for parsing tags and attributes
   var startTag = /^<([\w:-]+)((?:\s*[\w:-]+(?:\s*=\s*(?:(?:"[^"]*")|(?:'[^']*')|[^>\s]+))?)*)\s*(\/?)>/,
-      endTag = /^<\/(\w+)[^>]*>/,
+      endTag = /^<\/([\w:-]+)[^>]*>/,
       attr = /([\w:-]+)(?:\s*=\s*(?:(?:"((?:\\.|[^"])*)")|(?:'((?:\\.|[^'])*)')|([^>\s]+)))?/g,
       doctype = /^<!DOCTYPE [^>]+>/i;
     


### PR DESCRIPTION
Minifying the following markup results in an incorrect parse with the div ending up inside the custom tag. This causes problems when minifying angular templates since they often use hyphens in custom tag names. I just updated the endTag regExp to include hyphens (the start tag already accepted them).

``` html
<!doctype html>
<html>
<head>
  <title>custom tags dash problem</title>
</head>
<body>
  <customout>
    <custom-in>
    </custom-in>
    <div class="">
      My parent div is a sibling of customin
    </div>
  </customout>
</body>
</html>
```
