### PR TITLE
htmlparser: iframe and object tags in inline list

### DIFF
--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -39,7 +39,7 @@
   var block = makeMap("address,applet,blockquote,button,center,dd,del,dir,div,dl,dt,fieldset,form,frameset,hr,iframe,ins,isindex,li,map,menu,noframes,noscript,object,ol,p,pre,script,table,tbody,td,tfoot,th,thead,tr,ul");
 
   // Inline Elements - HTML 4.01
-  var inline = makeMap("a,abbr,acronym,applet,b,basefont,bdo,big,br,button,cite,code,del,dfn,em,font,i,iframe,img,input,ins,kbd,label,map,object,q,s,samp,script,select,small,span,strike,strong,sub,sup,textarea,tt,u,var");
+  var inline = makeMap("a,abbr,acronym,applet,b,basefont,bdo,big,br,button,cite,code,del,dfn,em,font,i,img,input,ins,kbd,label,map,q,s,samp,script,select,small,span,strike,strong,sub,sup,textarea,tt,u,var");
 
   // Elements that you can, intentionally, leave open
   // (and which close themselves)


### PR DESCRIPTION
The `<object>` and `<iframe>` tags are in the inline list as well as the block list. This causes contained elements to be ejected outside of the iframe/object. This PR just removes iframe and object from the inline list.

Julien
