### PR TITLE
HTML5 as an option

### DIFF
--- a/dist/all.js
+++ b/dist/all.js
@@ -160,6 +160,10 @@
 
     function parseStartTag( tag, tagName, rest, unary ) {
 
+      while ( !handler.html5 && stack.last() && inline[ stack.last() ]) {
+        parseEndTag( "", stack.last() );
+      }
+
       if ( closeSelf[ tagName ] && stack.last() == tagName ) {
         parseEndTag( "", tagName );
       }
@@ -651,6 +655,8 @@
     }
 
     HTMLParser(value, {
+      html5: typeof options.html5 !== 'undefined' ? options.html5 : true,
+
       start: function( tag, attrs ) {
         tag = tag.toLowerCase();
         currentTag = tag;

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -313,6 +313,8 @@
     }
 
     HTMLParser(value, {
+      html5: typeof options.html5 !== 'undefined' ? options.html5 : true,
+
       start: function( tag, attrs ) {
         tag = tag.toLowerCase();
         currentTag = tag;

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -160,6 +160,10 @@
 
     function parseStartTag( tag, tagName, rest, unary ) {
 
+      while ( !handler.html5 && stack.last() && inline[ stack.last() ]) {
+        parseEndTag( "", stack.last() );
+      }
+
       if ( closeSelf[ tagName ] && stack.last() == tagName ) {
         parseEndTag( "", tagName );
       }

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -584,4 +584,31 @@
     equal(minify(input, { removeOptionalTags: true }), output);
   });
 
+ test('custom components', function(){
+    input = '<custom-component>Oh, my.</custom-component>';
+    output = '<custom-component>Oh, my.</custom-component>';
+
+    equal(minify(input), output);
+  });
+
+  test('HTML4: anchor with block elements', function(){
+    input = '<a href="#"><div>Well, look at me! I\'m a div!</div></a>';
+    output = '<a href="#"></a><div>Well, look at me! I\'m a div!</div>';
+
+    equal(minify(input, { html5: false }), output);
+  });
+
+  test('HTML5: anchor with block elements', function(){
+    input = '<a href="#"><div>Well, look at me! I\'m a div!</div></a>';
+    output = '<a href="#"><div>Well, look at me! I\'m a div!</div></a>';
+
+    equal(minify(input, { html5: true }), output);
+  });
+
+  test('HTML5: enabled by default', function(){
+    input = '<a href="#"><div>Well, look at me! I\'m a div!</div></a>';
+
+    equal(minify(input, { html5: true }), minify(input));
+  });
+
 })(typeof exports === 'undefined' ? window : exports);


### PR DESCRIPTION
HTML5 is still the default, however `{ html5: false }` will essentially revert to the old system. Let me know if you would have implemented this differently, and I'll be happy to make adjustments.
