### PR TITLE
Unquoted attribute values

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -71,9 +71,8 @@
   }
 
   function canRemoveAttributeQuotes(value) {
-    // http://www.w3.org/TR/html4/intro/sgmltut.html#attributes
-    // avoid \w, which could match unicode in some implementations
-    return (/^[a-zA-Z0-9-._:]+$/).test(value);
+    // http://mathiasbynens.be/notes/unquoted-attribute-values
+    return /^[^\x20\t\n\f\r"'`=<>]+$/.test(value);
   }
 
   function attributesInclude(attributes, attribute) {

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -440,10 +440,13 @@
     equal(minify(input, { removeAttributeQuotes: true }), '<input value="hello world">');
 
     input = '<a href="#" title="foo#bar">x</a>';
-    equal(minify(input, { removeAttributeQuotes: true }), '<a href="#" title="foo#bar">x</a>');
+    equal(minify(input, { removeAttributeQuotes: true }), '<a href=# title=foo#bar>x</a>');
 
-    input = '<a href="http://example.com" title="blah">\nfoo\n\n</a>';
-    equal(minify(input, { removeAttributeQuotes: true }), '<a href="http://example.com" title=blah>\nfoo\n\n</a>');
+    input = '<a href="http://example.com/" title="blah">\nfoo\n\n</a>';
+    equal(minify(input, { removeAttributeQuotes: true }), '<a href=http://example.com/ title=blah>\nfoo\n\n</a>');
+
+    input = '<p class=foo|bar:baz></p>';
+    equal(minify(input, { removeAttributeQuotes: true }), '<p class=foo|bar:baz></p>');
   });
 
   test('collapsing whitespace', function() {


### PR DESCRIPTION
See http://mathiasbynens.be/notes/unquoted-attribute-values for how browsers behave when it comes to unquoted attribute values, and what the HTML spec (based on pre-existing behavior) says about it.

Closes #60 and #61.
