### PR TITLE
Add code, kbd and q to list of tags with space around them.

### DIFF
--- a/dist/all.js
+++ b/dist/all.js
@@ -384,7 +384,7 @@
 
   function collapseWhitespaceSmart(str, prevTag, nextTag) {
     // array of tags that will maintain a single space outside of them
-    var tags = ['a', 'b', 'big', 'button', 'em', 'font','i',  'img', 'mark', 's', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'tt', 'u'];
+    var tags = ['a', 'b', 'big', 'button', 'code', 'em', 'font', 'i', 'img', 'kbd', 'mark', 'q', 's', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'tt', 'u'];
 
     if (prevTag && (prevTag.substr(0,1) !== '/'
       || ( prevTag.substr(0,1) === '/' && tags.indexOf(prevTag.substr(1)) === -1))) {

--- a/dist/all.js
+++ b/dist/all.js
@@ -384,15 +384,13 @@
 
   function collapseWhitespaceSmart(str, prevTag, nextTag) {
     // array of tags that will maintain a single space outside of them
-    var tags = ['a', 'b', 'big', 'button', 'code', 'em', 'font', 'i', 'img', 'kbd', 'mark', 'q', 's', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'tt', 'u'];
+    var tags = ['a', 'b', 'big', 'button', 'code', 'em', 'font', 'i', 'kbd', 'mark', 'q', 's', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'tt', 'u'];
 
-    if (prevTag && (prevTag.substr(0,1) !== '/'
-      || ( prevTag.substr(0,1) === '/' && tags.indexOf(prevTag.substr(1)) === -1))) {
+    if (prevTag && prevTag !== 'img' && (prevTag.substr(0,1) !== '/' || tags.indexOf(prevTag.substr(1)) === -1)) {
       str = str.replace(/^\s+/, '');
     }
 
-    if (nextTag && (nextTag.substr(0,1) === '/'
-      || ( nextTag.substr(0,1) !== '/' && tags.indexOf(nextTag) === -1))) {
+    if (nextTag && nextTag !== 'img' && (nextTag.substr(0,1) === '/' || tags.indexOf(nextTag) === -1)) {
       str = str.replace(/\s+$/, '');
     }
 

--- a/dist/all.js
+++ b/dist/all.js
@@ -413,9 +413,8 @@
   }
 
   function canRemoveAttributeQuotes(value) {
-    // http://www.w3.org/TR/html4/intro/sgmltut.html#attributes
-    // avoid \w, which could match unicode in some implementations
-    return (/^[a-zA-Z0-9-._:]+$/).test(value);
+    // http://mathiasbynens.be/notes/unquoted-attribute-values
+    return (/^[^\x20\t\n\f\r"'`=<>]+$/).test(value);
   }
 
   function attributesInclude(attributes, attribute) {

--- a/dist/all.js
+++ b/dist/all.js
@@ -386,11 +386,13 @@
     // array of tags that will maintain a single space outside of them
     var tags = ['a', 'b', 'big', 'button', 'code', 'em', 'font', 'i', 'kbd', 'mark', 'q', 's', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'tt', 'u'];
 
-    if (prevTag && prevTag !== 'img' && (prevTag.substr(0,1) !== '/' || tags.indexOf(prevTag.substr(1)) === -1)) {
+    if (prevTag && prevTag !== 'img' && (prevTag.substr(0,1) !== '/'
+      || ( prevTag.substr(0,1) === '/' && tags.indexOf(prevTag.substr(1)) === -1))) {
       str = str.replace(/^\s+/, '');
     }
 
-    if (nextTag && nextTag !== 'img' && (nextTag.substr(0,1) === '/' || tags.indexOf(nextTag) === -1)) {
+    if (nextTag && nextTag !== 'img' && (nextTag.substr(0,1) === '/'
+      || ( nextTag.substr(0,1) !== '/' && tags.indexOf(nextTag) === -1))) {
       str = str.replace(/\s+$/, '');
     }
 

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -42,7 +42,7 @@
 
   function collapseWhitespaceSmart(str, prevTag, nextTag) {
     // array of tags that will maintain a single space outside of them
-    var tags = ['a', 'b', 'big', 'button', 'code', 'em', 'font','i',  'img', 'kbd', 'mark', 'q', 's', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'tt', 'u'];
+    var tags = ['a', 'b', 'big', 'button', 'code', 'em', 'font', 'i', 'img', 'kbd', 'mark', 'q', 's', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'tt', 'u'];
 
     if (prevTag && (prevTag.substr(0,1) !== '/'
       || ( prevTag.substr(0,1) === '/' && tags.indexOf(prevTag.substr(1)) === -1))) {

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -44,11 +44,13 @@
     // array of tags that will maintain a single space outside of them
     var tags = ['a', 'b', 'big', 'button', 'code', 'em', 'font', 'i', 'kbd', 'mark', 'q', 's', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'tt', 'u'];
 
-    if (prevTag && prevTag !== 'img' && (prevTag.substr(0,1) !== '/' || tags.indexOf(prevTag.substr(1)) === -1)) {
+    if (prevTag && prevTag !== 'img' && (prevTag.substr(0,1) !== '/'
+      || ( prevTag.substr(0,1) === '/' && tags.indexOf(prevTag.substr(1)) === -1))) {
       str = str.replace(/^\s+/, '');
     }
 
-    if (nextTag && nextTag !== 'img' && (nextTag.substr(0,1) === '/' || tags.indexOf(nextTag) === -1)) {
+    if (nextTag && nextTag !== 'img' && (nextTag.substr(0,1) === '/'
+      || ( nextTag.substr(0,1) !== '/' && tags.indexOf(nextTag) === -1))) {
       str = str.replace(/\s+$/, '');
     }
 

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -42,7 +42,7 @@
 
   function collapseWhitespaceSmart(str, prevTag, nextTag) {
     // array of tags that will maintain a single space outside of them
-    var tags = ['a', 'b', 'big', 'button', 'em', 'font','i',  'img', 'mark', 's', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'tt', 'u'];
+    var tags = ['a', 'b', 'big', 'button', 'code', 'em', 'font','i',  'img', 'kbd', 'mark', 'q', 's', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'tt', 'u'];
 
     if (prevTag && (prevTag.substr(0,1) !== '/'
       || ( prevTag.substr(0,1) === '/' && tags.indexOf(prevTag.substr(1)) === -1))) {

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -72,7 +72,7 @@
 
   function canRemoveAttributeQuotes(value) {
     // http://mathiasbynens.be/notes/unquoted-attribute-values
-    return /^[^\x20\t\n\f\r"'`=<>]+$/.test(value);
+    return (/^[^\x20\t\n\f\r"'`=<>]+$/).test(value);
   }
 
   function attributesInclude(attributes, attribute) {

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -42,15 +42,13 @@
 
   function collapseWhitespaceSmart(str, prevTag, nextTag) {
     // array of tags that will maintain a single space outside of them
-    var tags = ['a', 'b', 'big', 'button', 'code', 'em', 'font', 'i', 'img', 'kbd', 'mark', 'q', 's', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'tt', 'u'];
+    var tags = ['a', 'b', 'big', 'button', 'code', 'em', 'font', 'i', 'kbd', 'mark', 'q', 's', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'tt', 'u'];
 
-    if (prevTag && (prevTag.substr(0,1) !== '/'
-      || ( prevTag.substr(0,1) === '/' && tags.indexOf(prevTag.substr(1)) === -1))) {
+    if (prevTag && prevTag !== 'img' && (prevTag.substr(0,1) !== '/' || tags.indexOf(prevTag.substr(1)) === -1)) {
       str = str.replace(/^\s+/, '');
     }
 
-    if (nextTag && (nextTag.substr(0,1) === '/'
-      || ( nextTag.substr(0,1) !== '/' && tags.indexOf(nextTag) === -1))) {
+    if (nextTag && nextTag !== 'img' && (nextTag.substr(0,1) === '/' || tags.indexOf(nextTag) === -1)) {
       str = str.replace(/\s+$/, '');
     }
 

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -78,7 +78,7 @@
     equal(minify('   <p>blah</p>\n\n\n   '), '<p>blah</p>');
     // tags from collapseWhitespaceSmart()
     ['a', 'b', 'big', 'button', 'code', 'em', 'font', 'i', 'kbd', 'mark', 'q', 's', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'tt', 'u'].forEach(function(el){
-      equal(minify('<p>foo <'+el+'>baz</'+el+'> bar</p>'), '<p>foo<'+el+'>baz</'+el+'> bar</p>');
+      equal(minify('<p>foo <'+el+'>baz</'+el+'> bar</p>'), '<p>foo <'+el+'>baz</'+el+'> bar</p>');
       equal(minify('<p>foo<'+el+'>baz</'+el+'>bar</p>'), '<p>foo<'+el+'>baz</'+el+'>bar</p>');
     })   
     equal(minify('<p>foo <img> bar</p>'), '<p>foo <img> bar</p>');

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -76,6 +76,13 @@
 
   test('space normalization around text', function(){
     equal(minify('   <p>blah</p>\n\n\n   '), '<p>blah</p>');
+    // tags from collapseWhitespaceSmart()
+    ['a', 'b', 'big', 'button', 'code', 'em', 'font', 'i', 'kbd', 'mark', 'q', 's', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'tt', 'u'].forEach(function(el){
+      equal(minify('<p>foo <'+el+'>baz</'+el+'> bar</p>'), '<p>foo<'+el+'>baz</'+el+'> bar</p>');
+      equal(minify('<p>foo<'+el+'>baz</'+el+'>bar</p>'), '<p>foo<'+el+'>baz</'+el+'>bar</p>');
+    })   
+    equal(minify('<p>foo <img> bar</p>'), '<p>foo <img> bar</p>');
+    equal(minify('<p>foo<img>bar</p>'), '<p>foo<img>bar</p>');
   });
 
   test('doctype normalization', function() {

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -78,11 +78,19 @@
     equal(minify('   <p>blah</p>\n\n\n   '), '<p>blah</p>');
     // tags from collapseWhitespaceSmart()
     ['a', 'b', 'big', 'button', 'code', 'em', 'font', 'i', 'kbd', 'mark', 'q', 's', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'tt', 'u'].forEach(function(el){
-      equal(minify('<p>foo <'+el+'>baz</'+el+'> bar</p>'), '<p>foo <'+el+'>baz</'+el+'> bar</p>');
-      equal(minify('<p>foo<'+el+'>baz</'+el+'>bar</p>'), '<p>foo<'+el+'>baz</'+el+'>bar</p>');
+      equal(minify('<p>foo <'+el+'>baz</'+el+'> bar</p>', {collapseWhitespace: true}), '<p>foo <'+el+'>baz</'+el+'> bar</p>');
+      equal(minify('<p>foo<'+el+'>baz</'+el+'>bar</p>', {collapseWhitespace: true}), '<p>foo<'+el+'>baz</'+el+'>bar</p>');
+      equal(minify('<p>foo <'+el+'>baz</'+el+'>bar</p>', {collapseWhitespace: true}), '<p>foo <'+el+'>baz</'+el+'>bar</p>');
+      equal(minify('<p>foo<'+el+'>baz</'+el+'> bar</p>', {collapseWhitespace: true}), '<p>foo<'+el+'>baz</'+el+'> bar</p>');
+      equal(minify('<p>foo <'+el+'> baz </'+el+'> bar</p>', {collapseWhitespace: true}), '<p>foo <'+el+'>baz</'+el+'> bar</p>');
+      equal(minify('<p>foo<'+el+'> baz </'+el+'>bar</p>', {collapseWhitespace: true}), '<p>foo<'+el+'>baz</'+el+'>bar</p>');
+      equal(minify('<p>foo <'+el+'> baz </'+el+'>bar</p>', {collapseWhitespace: true}), '<p>foo <'+el+'>baz</'+el+'>bar</p>');
+      equal(minify('<p>foo<'+el+'> baz </'+el+'> bar</p>', {collapseWhitespace: true}), '<p>foo<'+el+'>baz</'+el+'> bar</p>');
     })   
-    equal(minify('<p>foo <img> bar</p>'), '<p>foo <img> bar</p>');
-    equal(minify('<p>foo<img>bar</p>'), '<p>foo<img>bar</p>');
+    equal(minify('<p>foo <img> bar</p>', {collapseWhitespace: true}), '<p>foo <img> bar</p>');
+    equal(minify('<p>foo<img>bar</p>', {collapseWhitespace: true}), '<p>foo<img>bar</p>');
+    equal(minify('<p>foo <img>bar</p>', {collapseWhitespace: true}), '<p>foo <img>bar</p>');
+    equal(minify('<p>foo<img> bar</p>', {collapseWhitespace: true}), '<p>foo<img> bar</p>');
   });
 
   test('doctype normalization', function() {


### PR DESCRIPTION
Currently, these tags get cinched up, e.g. `<p>Here's some<code>code</code>I wrote.</p>` and `<p>I said<q>yes!</q>and left.</p>`.
