### PR TITLE
Avoid collapsing `code` inline tag

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -42,7 +42,7 @@
 
   function collapseWhitespaceSmart(str, prevTag, nextTag) {
     // array of tags that will maintain a single space outside of them
-    var tags = ['a', 'b', 'big', 'button', 'em', 'font','i',  'img', 'mark', 's', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'tt', 'u'];
+    var tags = ['a', 'b', 'big', 'button', 'code', 'em', 'font','i',  'img', 'mark', 's', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'tt', 'u'];
 
     if (prevTag && (prevTag.substr(0,1) !== '/'
       || ( prevTag.substr(0,1) === '/' && tags.indexOf(prevTag.substr(1)) === -1))) {


### PR DESCRIPTION
I think there's a bug in current version:

``` javascript
    var input = 'a <code>hello world</code> example.';
    var output = minify(input, { collapseWhitespace: true });

    output; // 'a<code>hello world</code>example.'
```

`code` is an inline element, collapsing should be avoided.
