### PR TITLE
Patch 2

### DIFF
--- a/dist/all.js
+++ b/dist/all.js
@@ -731,10 +731,10 @@
           }
         }
         if (options.collapseWhitespace) {
-          if (!stackNoTrimWhitespace.length && _canTrimWhitespace(currentTag, currentAttrs)) {
+          if (!stackNoTrimWhitespace.length) {
             text = (prevTag || nextTag) ? collapseWhitespaceSmart(text, prevTag, nextTag) : trimWhitespace(text);
           }
-          if (!stackNoCollapseWhitespace.length && _canCollapseWhitespace(currentTag, currentAttrs)) {
+          if (!stackNoCollapseWhitespace.length) {
             text = collapseWhitespace(text);
           }
         }

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -387,10 +387,10 @@
           }
         }
         if (options.collapseWhitespace) {
-          if (!stackNoTrimWhitespace.length && _canTrimWhitespace(currentTag, currentAttrs)) {
+          if (!stackNoTrimWhitespace.length) {
             text = (prevTag || nextTag) ? collapseWhitespaceSmart(text, prevTag, nextTag) : trimWhitespace(text);
           }
-          if (!stackNoCollapseWhitespace.length && _canCollapseWhitespace(currentTag, currentAttrs)) {
+          if (!stackNoCollapseWhitespace.length) {
             text = collapseWhitespace(text);
           }
         }

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -168,9 +168,7 @@
     output = '<!--[if IE 7]>'+
                 '<link rel="stylesheet" href="/css/ie7-fixes.css" type="text/css" />'+
              '<![endif]-->'
-
     equal(minify(input, { removeComments: true }), output);
-
 
     input = '<!--[if lte IE 6]>\n    \n   \n\n\n\t' +
               '<p title=" sigificant     whitespace   ">blah blah</p>' +
@@ -178,7 +176,6 @@
     output = '<!--[if lte IE 6]>' +
               '<p title=" sigificant     whitespace   ">blah blah</p>' +
             '<![endif]-->';
-
     equal(minify(input, { removeComments: true }), output);
   });
 
@@ -515,6 +512,28 @@
 
     input = '<div><textarea></textarea>    </div>';
     output = '<div><textarea></textarea></div>';
+    equal(minify(input, { collapseWhitespace: true }), output);
+
+    input = '<div><pre> $foo = "baz"; </pre>    </div>';
+    output = '<div><pre> $foo = "baz"; </pre></div>';
+    equal(minify(input, { collapseWhitespace: true }), output);
+
+     input = '<script type=\"text\/javascript\">var = \"hello\";<\/script>\r\n\r\n\r\n'              +
+             '<style type=\"text\/css\">#foo { color: red;        }          <\/style>\r\n\r\n\r\n'  +
+             '<div>\r\n  <div>\r\n    <div><!-- hello -->\r\n      <div>'                            +
+             '<!--! hello -->\r\n        <div>\r\n          <div class=\"\">\r\n\r\n            '    +
+             '<textarea disabled=\"disabled\">     this is a textarea <\/textarea>\r\n          '    +
+             '<\/div>\r\n        <\/div>\r\n      <\/div>\r\n    <\/div>\r\n  <\/div>\r\n<\/div>'    +
+             '<pre>       \r\nxxxx<\/pre><span>x<\/span> <span>Hello<\/span> <b>billy<\/b>     \r\n' +
+             '<input type=\"text\">\r\n<textarea><\/textarea>\r\n<pre><\/pre>';
+    output = '<script type="text/javascript">var = "hello";</script>'                                +
+             '<style type="text/css">#foo { color: red;        }</style>'                            +
+             '<div><div><div>'                                                                       +
+             '<!-- hello --><div><!--! hello --><div><div class="">'                                 +
+             '<textarea disabled="disabled">     this is a textarea </textarea>'                     +
+             '</div></div></div></div></div></div>'                                                  +
+             '<pre>       \r\nxxxx</pre><span>x</span> <span>Hello</span> <b>billy</b>'              +
+             '<input type="text"><textarea></textarea><pre></pre>';
     equal(minify(input, { collapseWhitespace: true }), output);
 
     input = '<pre title="some title...">   hello     world </pre>';

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -147,7 +147,6 @@
     equal(minify(input, { removeComments: false, collapseWhitespace: true }), output);
 
     input = '<p rel="<!-- comment in attribute -->" title="<!--! ignored comment in attribute -->">foo</p>';
-    output = '<p rel="" title="<!--! ignored comment in attribute -->">foo</p>';
     equal(minify(input, { removeComments: true }), input);
   });
 

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -513,6 +513,10 @@
     output = '<textarea> foo bar     baz \n\n   x \t    y </textarea>';
     equal(minify(input, { collapseWhitespace: true }), output);
 
+    input = '<div><textarea></textarea>    </div>';
+    output = '<div><textarea></textarea></div>';
+    equal(minify(input, { collapseWhitespace: true }), output);
+
     input = '<pre title="some title...">   hello     world </pre>';
     output = '<pre title="some title...">   hello     world </pre>';
     equal(minify(input, { collapseWhitespace: true }), output);


### PR DESCRIPTION
Unless I'm missing something, I think this is a few for #77 (`<textarea>` & `<pre>` whitespace/collapsing problems). After a bit of testing, I realized that by removing `_canTrimWhitespace(...)` and `_canCollapseWhitespace()` fixed the bug. Reasoning: At this point, the `stackNoTrimWhitespace` has already been popped and checking for `!stackNo...length` gives us the green light to do further checking (i.e. `smart` collapse or `trim`). Having `_canCollapseWhitespace(currentTag, currentAttrs)` caused the logic to return false for `pre` and `textarea`. I'm sending this pull request to spark further discussion; I'd love to get some peer review/feedback on this change.
