### PR TITLE
Preserve quotes if attribute ends with a trailing slash

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -76,7 +76,9 @@
 
   function canRemoveAttributeQuotes(value) {
     // http://mathiasbynens.be/notes/unquoted-attribute-values
-    return (/^[^\x20\t\n\f\r"'`=<>]+$/).test(value) && !(/\/$/ ).test(value);
+    return (/^[^\x20\t\n\f\r"'`=<>]+$/).test(value) && !(/\/$/ ).test(value) &&
+    // make sure trailing slash is not interpreted as HTML self-closing tag
+        !(/\/$/).test(value);
   }
 
   function attributesInclude(attributes, attribute) {

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -76,7 +76,7 @@
 
   function canRemoveAttributeQuotes(value) {
     // http://mathiasbynens.be/notes/unquoted-attribute-values
-    return (/^[^\x20\t\n\f\r"'`=<>]+$/).test(value);
+    return (/^[^\x20\t\n\f\r"'`=<>]+$/).test(value) && !(/\/$/ ).test(value);
   }
 
   function attributesInclude(attributes, attribute) {

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -483,7 +483,10 @@
     equal(minify(input, { removeAttributeQuotes: true }), '<a href=# title=foo#bar>x</a>');
 
     input = '<a href="http://example.com/" title="blah">\nfoo\n\n</a>';
-    equal(minify(input, { removeAttributeQuotes: true }), '<a href=http://example.com/ title=blah>\nfoo\n\n</a>');
+    equal(minify(input, { removeAttributeQuotes: true }), '<a href="http://example.com/" title=blah>\nfoo\n\n</a>');
+
+    input = '<a title="blah" href="http://example.com/">\nfoo\n\n</a>';
+    equal(minify(input, { removeAttributeQuotes: true }), '<a title=blah href="http://example.com/">\nfoo\n\n</a>');
 
     input = '<p class=foo|bar:baz></p>';
     equal(minify(input, { removeAttributeQuotes: true }), '<p class=foo|bar:baz></p>');


### PR DESCRIPTION
minified URLs in parameters, like `<a href="http://www.example.com/">` need to keept their quotes because `<a href=http://www.example.com/>` is interpreted as an URL without trailing slash
