### PR TITLE
Newlines should be collapsed to single space.

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -56,7 +56,7 @@
 
     if (prevTag && nextTag) {
       // strip non space whitespace then compress spaces to one
-      return str.replace(/[\t\n\r]+/g, '').replace(/[ ]+/g, ' ');
+      return str.replace(/[\t\n\r]+/g, ' ').replace(/[ ]+/g, ' ');
     }
 
     return str;

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -502,6 +502,10 @@
     output = '<p>foo bar</p>';
     equal(minify(input, { collapseWhitespace: true }), output);
 
+    input = '<p>foo\nbar</p>';
+    output = '<p>foo bar</p>';
+    equal(minify(input, { collapseWhitespace: true }), output);
+
     input = '<p> foo    <span>  blah     <i>   22</i>    </span> bar <img src=""></p>';
     output = '<p>foo <span>blah <i>22</i></span> bar <img src=""></p>';
     equal(minify(input, { collapseWhitespace: true }), output);


### PR DESCRIPTION
Currently a single newline is completely removed if whitespace collapsing is enabled. This is not correct. It is treated as whitespace by browsers and should be collapsed to a single space.

Pull request includes fix and test case.
