### PR TITLE
Test runner does not minify, so don't test minified version

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -5,7 +5,7 @@
     <title>HTML Minifier Tests</title>
     <link rel="stylesheet" href="http://oss.maxcdn.com/libs/qunit/1.13/qunit.min.css">
     <script src="http://oss.maxcdn.com/libs/qunit/1.13/qunit.min.js"></script>
-    <script src="../dist/all.min.js"></script>
+    <script src="../dist/all.js"></script>
   </head>
   <body>
 

--- a/tests/lint-tests.html
+++ b/tests/lint-tests.html
@@ -5,7 +5,7 @@
     <title>HTML Lint Tests</title>
     <link rel="stylesheet" href="http://oss.maxcdn.com/libs/qunit/1.13/qunit.min.css">
     <script src="http://oss.maxcdn.com/libs/qunit/1.13/qunit.min.js"></script>
-    <script src="../dist/all.min.js"></script>
+    <script src="../dist/all.js"></script>
   </head>
   <body>
     <h1 id="qunit-header">HTML Lint</h1>

--- a/tests/lint.js
+++ b/tests/lint.js
@@ -1,7 +1,7 @@
 (function(global){
 
-  var minify = global.minify || require('../dist/all.min.js').minify,
-      HTMLLint = HTMLLint || require('../dist/all.min.js').HTMLLint,
+  var minify = global.minify || require('../dist/all.js').minify,
+      HTMLLint = HTMLLint || require('../dist/all.js').HTMLLint,
       input,
       output,
       lint = new HTMLLint();

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -1,6 +1,6 @@
 (function(global){
 
-  var minify = global.minify || require('../dist/all.min.js').minify,
+  var minify = global.minify || require('../dist/all.js').minify,
       input,
       output;
 


### PR DESCRIPTION
This will ease future development, since it will enable test-driven development.

This enables:

```
# change code
npm tests
```

Instead of:

```
# change code
npm run build
npm run minify
npm test
```

Also, one less concatenation to be performed while developing.
