### PR TITLE
Fixed bug in custom testers

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -310,7 +310,7 @@
         t = new Date();
 
     function _canCollapseWhitespace(tag, attrs) {
-      return canCollapseWhitespace(tag) || options.canTrimWhitespace(tag, attrs);
+      return canCollapseWhitespace(tag) || options.canCollapseWhitespace(tag, attrs);
     }
 
     function _canTrimWhitespace(tag, attrs) {


### PR DESCRIPTION
Even when a `canCollapseWhitespace` 'tester' was passed, it was never used. The code in `_canCollapseWhitespace` erroneously refered to `options.canTrimWhitespace`. This change fixes this.
