### PR TITLE
Downgrade qunit so that node.js 0.8 works again.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "grunt-contrib-qunit": "0.4.x",
     "grunt-contrib-uglify": "0.3.x",
     "grunt-exec": "0.4.x",
-    "grunt-jscs-checker": "~0.4.0",
+    "grunt-jscs-checker": "0.4.x",
     "load-grunt-tasks": "0.3.x",
-    "qunit": "0.6.x",
+    "qunit": "0.5.x",
     "time-grunt": "0.2.x"
   },
   "files": [


### PR DESCRIPTION
More and more issues arise from supporting node.js 0.8...
