### PR TITLE
Don't add empty string value to valueless attributes

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -267,7 +267,7 @@
 
     attrValue = cleanAttributeValue(tag, attrName, attrValue, options);
 
-    if (!options.removeAttributeQuotes ||
+    if (attrValue !== undefined && !options.removeAttributeQuotes ||
         !canRemoveAttributeQuotes(attrValue)) {
       attrValue = '"' + attrValue + '"';
     }
@@ -277,8 +277,8 @@
       return '';
     }
 
-    if (options.collapseBooleanAttributes &&
-        isBooleanAttribute(attrName)) {
+    if (attrValue === undefined || (options.collapseBooleanAttributes &&
+        isBooleanAttribute(attrName))) {
       attrFragment = attrName;
     }
     else {

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -216,11 +216,11 @@
           var value = arguments[2] ? arguments[2] :
             arguments[3] ? arguments[3] :
             arguments[4] ? arguments[4] :
-            fillAttrs[name] ? name : '';
+            fillAttrs[name] ? name : arguments[2];
           attrs.push({
             name: name,
             value: value,
-            escaped: value.replace(/(^|[^\\])"/g, '$1&quot;') //"
+            escaped: value && value.replace(/(^|[^\\])"/g, '$1&quot;') //"
           });
         });
 

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -35,7 +35,7 @@
     equal(minify('<ng-include src="x"></ng-include>'), '<ng-include src="x"></ng-include>');
     equal(minify('<ng:include src="x"></ng:include>'), '<ng:include src="x"></ng:include>');
     equal(minify('<ng-include src="\'views/partial-notification.html\'"></ng-include><div ng-view></div>'),
-      '<ng-include src="\'views/partial-notification.html\'"></ng-include><div ng-view=""></div>'
+      '<ng-include src="\'views/partial-notification.html\'"></ng-include><div ng-view></div>'
     );
 
     // https://github.com/kangax/html-minifier/issues/41


### PR DESCRIPTION
For example does not change `<div ng-transclude></div>` to `<div ng-transclude=""></div>`, but leaves empty attributes as is. Possibly fixes issue #9, although I am not sure what is meant there exactly.
