### PR TITLE
Ooops, CLI does not work when html-minifier is installed with npm install html-minifier -g

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,6 @@ How does HTMLMinifier compare to [another solution](http://www.willpeavy.com/min
 | [Eloquent Javascript](http://eloquentjavascript.net/print.html)             | 890         | <b>860</b>       |   872        |
 
 
-Installing with [npm](https://github.com/isaacs/npm):
-
-```
-npm install html-minifier
-```
-
 
 ## Options Quick Reference
 
@@ -58,7 +52,7 @@ npm install html-minifier
 Chunks of markup can be ignored by wrapping them with `<!-- htmlmin:ignore -->`.
 
 Installation Instructions
-----------------------------
+-------------------------
 
 From NPM for use as a command line app:
 ```

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   "dependencies": {
     "clean-css": "2.1.x",
     "uglify-js": "2.4.x",
-    "cli": "~0.6.2",
-    "change-case": "~2.1.1"
+    "cli": "0.6.x",
+    "change-case": "2.1.x"
   },
   "devDependencies": {
     "grunt": "0.4.x",
@@ -58,6 +58,8 @@
   },
   "files": [
     "dist",
+    "cli.js",
+    "sample-cli-config-file.conf",
     "CHANGELOG.md",
     "LICENSE"
   ],

--- a/sample-cli-config-file.conf
+++ b/sample-cli-config-file.conf
@@ -2,7 +2,7 @@
   "removeComments": false,
   "removeCommentsFromCDATA": false,
   "removeCDATASectionsFromCDATA": false,
-  "collapseWhitespace": false,
+  "collapseWhitespace": true,
   "conservativeCollapse": false,
   "collapseBooleanAttributes": false,
   "removeAttributeQuotes": false,


### PR DESCRIPTION
Today I installed html-minifier on a Mac with `npm install html-minifier -g` command and noticed that the CLI interface did not get installed at all... :(

Here is the fix: we must include `cli.js` in the `"files"` section of `package.json` file. It's kind of important.

While at it, I did some other improvements in my cli.js code, fixed a small issue in README.md file, etc.

Can you please merge these changes?

Thanks!!
