### PR TITLE
Add support for <wbr> tag.

### DIFF
--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -41,7 +41,7 @@
       endIgnore = /(%|\?)>/;
 
   // Empty Elements - HTML 4.01
-  var empty = makeMap('area,base,basefont,br,col,frame,hr,img,input,isindex,link,meta,param,embed');
+  var empty = makeMap('area,base,basefont,br,col,frame,hr,img,input,isindex,link,meta,param,embed,wbr');
 
   // Block Elements - HTML 4.01
   // var block = makeMap('address,applet,blockquote,button,center,dd,del,dir,div,dl,dt,fieldset,form,frameset,hr,iframe,ins,isindex,li,map,menu,noframes,noscript,object,ol,p,pre,script,table,tbody,td,tfoot,th,thead,tr,ul');


### PR DESCRIPTION
The current implementation does not appear to be aware of the <wbr> tag.  This is the "word break opportunity" tag, which is processed as a void element.  Without proper recognition of the <wbr> tag, htmlmin unfortunately adds illegal closing tags when processing HTML files that use it.

See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr

This pull request proposes a possible enhancement to support <wbr>.
