### PR TITLE
Do not treat translate attribtues as boolean values

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -155,7 +155,7 @@
   }
 
   function isBooleanAttribute(attrName) {
-    return (/^(?:allowfullscreen|async|autofocus|autoplay|checked|compact|controls|declare|default|defaultchecked|defaultmuted|defaultselected|defer|disabled|draggable|enabled|formnovalidate|hidden|indeterminate|inert|ismap|itemscope|loop|multiple|muted|nohref|noresize|noshade|novalidate|nowrap|open|pauseonexit|readonly|required|reversed|scoped|seamless|selected|sortable|spellcheck|translate|truespeed|typemustmatch|visible)$/).test(attrName);
+    return (/^(?:allowfullscreen|async|autofocus|autoplay|checked|compact|controls|declare|default|defaultchecked|defaultmuted|defaultselected|defer|disabled|draggable|enabled|formnovalidate|hidden|indeterminate|inert|ismap|itemscope|loop|multiple|muted|nohref|noresize|noshade|novalidate|nowrap|open|pauseonexit|readonly|required|reversed|scoped|seamless|selected|sortable|spellcheck|truespeed|typemustmatch|visible)$/).test(attrName);
   }
 
   function isUriTypeAttribute(attrName, tag) {


### PR DESCRIPTION
See #172 and the current draft of the HTML5 spec:
http://www.whatwg.org/specs/web-apps/current-work/multipage/elements.html#the-translate-attribute

Note that the `translate` spec is somewhat confusing, as elements inherit their `translate` value from their parent node(s), which is a fairly unusual behavior.  Thus, `translate` appears to be exposed to the DOM as a boolean, but requires a string value of `"yes"` or `"no"` to be set in the HTML document itself (ergo, it is not a "boolean" attribute from html-minifier's perspective).

Given that no browsers currently implement this API, and a few [libraries](http://angular-translate.github.io) happen to use custom `translate` attributes in the DOM, it seems pretty safe to remove this for now.
