### PR TITLE
Attributes can be wrapped with custom markup

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -337,7 +337,7 @@
       attrFragment = attrName + '=' + attrValue;
     }
 
-    return (' ' + attrFragment);
+    return (' ' + attr.customOpen + attrFragment + attr.customClose);
   }
 
   function setDefaultTesters(options) {
@@ -595,7 +595,9 @@
       },
       doctype: function(doctype) {
         buffer.push(options.useShortDoctype ? '<!DOCTYPE html>' : collapseWhitespace(doctype));
-      }
+      },
+      customAttrOpen: options.customAttrOpen,
+      customAttrClose: options.customAttrClose
     });
 
     results.push.apply(results, buffer);

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -502,6 +502,19 @@
     equal(minify(input, { removeAttributeQuotes: true }), '<p class=foo|bar:baz></p>');
   });
 
+  test('preserving custom attribute-wrapping markup', function() {
+    var customAttrOptions = {
+      customAttrOpen: /\{\{#if\s+\w+\}\}/,
+      customAttrClose: /\{\{\/if\}\}/
+    };
+
+    input = '<input {{#if value}}checked="checked"{{/if}}>';
+    equal(minify(input, customAttrOptions), '<input {{#if value}}checked="checked"{{/if}}>');
+
+    input = '<input checked="checked">';
+    equal(minify(input, customAttrOptions), '<input checked="checked">');
+  });
+
   test('collapsing whitespace', function() {
     input = '<script type="text/javascript">  \n\t   alert(1) \n\n\n  \t <\/script>';
     output = '<script type="text/javascript">alert(1)<\/script>';


### PR DESCRIPTION
Allows for recognizing attributes wrapped by handlebars conditionals (or whatever.)

``` html
<input {{#if condition}}checked{{/if}}>
```
