### PR TITLE
Don’t choke on valueless event attributes

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -186,7 +186,7 @@
   }
 
   function cleanAttributeValue(tag, attrName, attrValue, options, attrs) {
-    if (isEventAttribute(attrName)) {
+    if (attrValue && isEventAttribute(attrName)) {
       attrValue = trimWhitespace(attrValue).replace(/^javascript:\s*/i, '').replace(/\s*;$/, '');
       if (options.minifyJS) {
         var wrappedCode = '(function(){' + attrValue + '})()';

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -54,6 +54,8 @@
 
     // https://github.com/kangax/html-minifier/issues/169
     equal(minify('<a href>ok</a>'), '<a href>ok</a>');
+
+    equal(minify('<a onclick></a>'), '<a onclick></a>');
   });
 
   test('`minifiy` exists', function() {


### PR DESCRIPTION
As discovered by @toxinhead in #205, event attributes without values cause minification errors.
