### PR TITLE
Allow parsing custom attribute-join syntax

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -334,7 +334,7 @@
       attrFragment = attrName;
     }
     else {
-      attrFragment = attrName + '=' + attrValue;
+      attrFragment = attrName + attr.customAssign + attrValue;
     }
 
     return (' ' + attr.customOpen + attrFragment + attr.customClose);
@@ -611,6 +611,7 @@
       doctype: function(doctype) {
         buffer.push(options.useShortDoctype ? '<!DOCTYPE html>' : collapseWhitespace(doctype));
       },
+      customAttrAssign: options.customAttrAssign,
       customAttrSurround: options.customAttrSurround
     });
 

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -37,7 +37,13 @@
       startTagClose = /\s*(\/?)>/,
       endTag = /^<\/([\w:-]+)[^>]*>/,
       endingSlash = /\/>$/,
-      singleAttr = /([\w:-]+)(?:\s*=\s*(?:(?:"((?:\\.|[^"])*)")|(?:'((?:\\.|[^'])*)')|([^>\s]+)))?/,
+      singleAttrIdentifier = /([\w:-]+)/,
+      singleAttrAssign = /=/,
+      singleAttrValues = [
+        /"((?:\\.|[^"])*)"/.source, // attr value double quotes
+        /'((?:\\.|[^'])*)'/.source, // attr value, single quotes
+        /([^>\s]+)/.source          // attr value, no quotes
+      ],
       doctype = /^<!DOCTYPE [^>]+>/i,
       startIgnore = /<(%|\?)/,
       endIgnore = /(%|\?)>/;
@@ -92,6 +98,17 @@
   }
 
   function attrForHandler( handler ) {
+    var singleAttr = new RegExp(
+      singleAttrIdentifier.source
+      + '(?:\\s*'
+      + singleAttrAssign.source
+      + '\\s*'
+      + '(?:'
+      + singleAttrValues.join('|')
+      + ')'
+      + ')?'
+    );
+
     if ( handler.customAttrSurround ) {
       var attrClauses = [];
       for ( var i = handler.customAttrSurround.length - 1; i >= 0; i-- ) {

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -345,6 +345,7 @@
             name: name,
             value: value,
             escaped: value && value.replace(/(^|[^\\])"/g, '$1&quot;'),
+            customAssign: customAssign || '=',
             customOpen:  customOpen || '',
             customClose: customClose || ''
           });

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -101,7 +101,9 @@
     var singleAttr = new RegExp(
       singleAttrIdentifier.source
       + '(?:\\s*'
+      + '('
       + singleAttrAssign.source
+      + ')'
       + '\\s*'
       + '(?:'
       + singleAttrValues.join('|')
@@ -296,23 +298,26 @@
         var attrs = [];
 
         rest.replace(attr, function () {
-          var name, value, fallbackValue, customOpen, customClose;
+          var name, value, fallbackValue, customOpen, customClose, customAssign;
+          var ncp = 7; // number of captured parts, scalar
 
           name = arguments[1];
           if ( name ) {
-            fallbackValue = arguments[2];
-            value = fallbackValue || arguments[3] || arguments[4];
+            customAssign = arguments[2];
+            fallbackValue = arguments[3];
+            value = fallbackValue || arguments[4] || arguments[5];
           }
           else if ( handler.customAttrSurround ) {
             for ( var i = handler.customAttrSurround.length - 1; i >= 0; i-- ) {
-              name = arguments[i * 6 + 6];
+              name = arguments[i * ncp + 7];
+              customAssign = arguments[i * ncp + 8];
               if ( name ) {
-                fallbackValue = arguments[i * 6 + 7];
+                fallbackValue = arguments[i * ncp + 9];
                 value = fallbackValue
-                  || arguments[i * 6 + 8]
-                  || arguments[i * 6 + 9];
-                customOpen = arguments[i * 6 + 5];
-                customClose = arguments[i * 6 + 10];
+                  || arguments[i * ncp + 10]
+                  || arguments[i * ncp + 11];
+                customOpen = arguments[i * ncp + 6];
+                customClose = arguments[i * ncp + 12];
                 break;
               }
             }

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -555,6 +555,21 @@
     equal(minify(input, customAttrOptions), '<input {{#if value1}}checked{{/if}} {{#if value2}}data-attr=foo{{/if}}>');
   });
 
+  test('preserving custom attribute-joining markup', function() {
+    var polymerConditionalAttributeJoin = /\?=/;
+    var customAttrOptions = {
+      customAttrAssign: [ polymerConditionalAttributeJoin ]
+    };
+
+    input = '<div flex?="{{mode != cover}}"></div>';
+
+    equal(minify(input, customAttrOptions), input);
+
+    input = '<div flex?="{{mode != cover}}" class="foo"></div>';
+
+    equal(minify(input, customAttrOptions), input);
+  });
+
   test('collapsing whitespace', function() {
     input = '<script type="text/javascript">  \n\t   alert(1) \n\n\n  \t <\/script>';
     output = '<script type="text/javascript">alert(1)<\/script>';


### PR DESCRIPTION
Polymer Project markup supports conditional attributes which use a `attr?="value"` syntax, as [documented here](http://www.polymer-project.org/docs/polymer/binding-types.html#conditional-attributes).

This PR allows consumers to specify additional attr-join syntaxes, using the polymer requirements as a guideline.

@jmatsushita Fixes #208
