### PR TITLE
Use native Array#reduce instead of _.reduce

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -2,11 +2,10 @@
 
 var fs = require('fs'),
     exec = require('child_process').exec,
-    Table = require('cli-table'),
-    _ = require('underscore');
+    Table = require('cli-table');
 
 function average (arr) {
-  return _.reduce(arr, function(memo, num) {
+  return arr.reduce(function(memo, num) {
     return memo + num;
   }, 0) / arr.length;
 }

--- a/package.json
+++ b/package.json
@@ -56,8 +56,7 @@
     "grunt-jscs": "0.6.x",
     "load-grunt-tasks": "0.6.x",
     "qunit": "0.7.x",
-    "time-grunt": "0.4.x",
-    "underscore": "1.6.x"
+    "time-grunt": "0.4.x"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Array.prototype.reduce:
https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce

Underscore.js is unnecessary in this case.
