### PR TITLE
Short-circuit corpus scan

### DIFF
--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -165,7 +165,7 @@
       if ( !stack.last() || !special[ stack.last() ] ) {
 
         // Comment:
-        if ( html.indexOf('<!--') === 0 ) {
+        if ( /^<!--/.test( html ) ) {
           index = html.indexOf('-->');
 
           if ( index >= 0 ) {
@@ -178,7 +178,7 @@
         }
 
         // http://en.wikipedia.org/wiki/Conditional_comment#Downlevel-revealed_conditional_comment
-        if ( html.indexOf('<![') === 0 ) {
+        if ( /^<!\[/.test( html ) ) {
           index = html.indexOf(']>');
 
           if (index >= 0) {
@@ -211,7 +211,7 @@
         }
 
         // End tag:
-        else if ( html.indexOf('</') === 0 ) {
+        else if ( /^<\//.test( html ) ) {
           match = html.match( endTag );
 
           if ( match ) {
@@ -223,7 +223,7 @@
 
         // Start tag:
         }
-        else if ( html.indexOf('<') === 0 ) {
+        else if ( /^</.test( html ) ) {
           match = html.match( startTag );
           if ( match ) {
             html = html.substring( match[0].length );


### PR DESCRIPTION
Huge speed-ups by not scanning the entire html corpus when we only care about the beginning few characters.

Previously, the wikipedia benchmark was coming in around 7 seconds on my machine. With this change, it takes about 2 and a half seconds.
