### PR TITLE
Fix `.` in attribute name with appropriate regexp

### DIFF
--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -32,7 +32,7 @@
   'use strict';
 
   // Regular Expressions for parsing tags and attributes
-  var singleAttrIdentifier = /([\w:.-]+)/,
+  var singleAttrIdentifier = /([\w:\.-]+)/,
       singleAttrAssign = /=/,
       singleAttrAssigns = [ singleAttrAssign ],
       singleAttrValues = [
@@ -76,7 +76,7 @@
     var customStartTagAttrs;
 
     var startTagAttrs = new RegExp(
-        '(?:\\s*[\\w:.-]+'
+        '(?:\\s*[\\w:\\.-]+'
       +   '(?:\\s*'
       +     '(?:' + joinSingleAttrAssigns(handler) + ')'
       +     '\\s*(?:(?:"[^"]*")|(?:\'[^\']*\')|[^>\\s]+)'


### PR DESCRIPTION
The original implementation used the overly-permissive `.` in its regular expression, where a literal period is needed.
