### PR TITLE
Special-case svg tags, preserve case and slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ How does HTMLMinifier compare to [another solution](http://www.willpeavy.com/min
 | `removeEmptyElements`          | [Remove all elements with empty contents](http://perfectionkills.com/experimenting-with-html-minifier/#remove_empty_elements) | `false` |
 | `lint`                         | [Toggle linting](http://perfectionkills.com/experimenting-with-html-minifier/#validate_input_through_html_lint) | `false` |
 | `keepClosingSlash`             | Keep the trailing slash on singleton elements                            | `false` |
-| `caseSensitive`                | Treat attributes in case sensitive manner (useful for SVG; e.g. viewBox) | `false` |
+| `caseSensitive`                | Treat attributes in case sensitive manner (useful for custom html tags.) | `false` |
 | `minifyJS`                     | Minify Javascript in script elements and on* attributes (uses [UglifyJS](https://github.com/mishoo/UglifyJS2)) | `false` (could be `true`, `false`, `Object` (options)) |
 | `minifyCSS`                    | Minify CSS in style elements and style attributes (uses [clean-css](https://github.com/GoalSmashers/clean-css)) | `false` (could be `true`, `false`, `Object` (options)) |
 | `minifyURLs`                   | Minify URLs in various attributes (uses [relateurl](https://github.com/stevenvachon/relateurl)) | `false` (could be `Object` (options)) |
@@ -58,8 +58,15 @@ How does HTMLMinifier compare to [another solution](http://www.willpeavy.com/min
 | `customAttrSurround`           | Arrays of regex'es that allow to support custom attribute surround expressions (e.g. `<input {{#if value}}checked="checked"{{/if}}>`) | `[ ]` |
 | `customAttrCollapse`           | Regex that specifies custom attribute to strip newlines from (e.g. `/ng\-class/`) | |
 
+## Special cases
 
-Chunks of markup can be ignored by wrapping them with `<!-- htmlmin:ignore -->`.
+### Ignoring chunks of markup.
+
+If you have chunks of markup you would like preserved, you can wrap them `<!-- htmlmin:ignore -->`.
+
+### Preserving SVG tags
+
+SVG tags are automatically recognized, and when they are minified, both case-sensitivity and closing-slashes are preserved, regardless of the minification settings used for the rest of the file.
 
 ## Installation Instructions
 

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -857,10 +857,10 @@
   });
 
   test('caseSensitive', function() {
-    input = '<svg class="icon icon-activity-by-tag" xmlns="http://www.w3.org/2000/svg" width="100px" height="100px" viewBox="0 0 100 100"><linearGradient><stop offset="0%"></stop><stop offset="50%"></stop></linearGradient></svg>';
+    input = '<div mixedCaseAttribute="value"></div>';
 
-    var caseSensitiveOutput = '<svg class="icon icon-activity-by-tag" xmlns="http://www.w3.org/2000/svg" width="100px" height="100px" viewBox="0 0 100 100"><linearGradient><stop offset="0%"></stop><stop offset="50%"></stop></linearGradient></svg>';
-    var caseInSensitiveOutput = '<svg class="icon icon-activity-by-tag" xmlns="http://www.w3.org/2000/svg" width="100px" height="100px" viewbox="0 0 100 100"><lineargradient><stop offset="0%"></stop><stop offset="50%"></stop></lineargradient></svg>';
+    var caseSensitiveOutput = '<div mixedCaseAttribute="value"></div>';
+    var caseInSensitiveOutput = '<div mixedcaseattribute="value"></div>';
 
     equal(minify(input), caseInSensitiveOutput);
     equal(minify(input, { caseSensitive: true }), caseSensitiveOutput);
@@ -880,6 +880,33 @@
             '</audio>';
 
     equal(minify(input, { removeOptionalTags: true }), output);
+  });
+
+  test('mixed html and svg', function() {
+    input = '<html><body>\n' +
+      '  <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"\n' +
+      '     width="612px" height="502.174px" viewBox="0 65.326 612 502.174" enable-background="new 0 65.326 612 502.174"\n' +
+      '     xml:space="preserve" class="logo">' +
+      '' +
+      '    <ellipse class="ground" cx="283.5" cy="487.5" rx="259" ry="80"/>' +
+      '    <polygon points="100,10 40,198 190,78 10,78 160,198"\n' +
+      '      style="fill:lime;stroke:purple;stroke-width:5;fill-rule:evenodd;" />\n' +
+      '    <filter id="pictureFilter">\n' +
+      '      <feGaussianBlur stdDeviation="15" />\n' +
+      '    </filter>\n' +
+      '  </svg>\n' +
+      '</body></html>';
+
+    output = '<html><body>' +
+      '<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="612px" height="502.174px" viewBox="0 65.326 612 502.174" enable-background="new 0 65.326 612 502.174" xml:space="preserve" class="logo">' +
+      '<ellipse class="ground" cx="283.5" cy="487.5" rx="259" ry="80"/>' +
+      '<polygon points="100,10 40,198 190,78 10,78 160,198" style="fill:lime;stroke:purple;stroke-width:5;fill-rule:evenodd"/>' +
+      '<filter id="pictureFilter"><feGaussianBlur stdDeviation="15"/></filter>' +
+      '</svg>' +
+      '</body></html>';
+
+    // Should preserve case-sensitivity and closing slashes within svg tags
+    equal(minify(input, { collapseWhitespace: true }), output);
   });
 
   test('nested quotes', function() {


### PR DESCRIPTION
Fixes https://github.com/kangax/html-minifier/issues/285

This is a pretty heavy-handed approach in that we override the user-supplied `keepClosingSlash` and `caseSensitive` options when the minifier encounters an svg tag.

Options are stored in a stack, and creating the stack relies on `Object.create` which may not be supported in all our runtimes.

Imbalanced input can lead to an over-popped options stack and a very ungraceful failure.
