### PR TITLE
Throw when fs.stat callback provides error

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -77,6 +77,10 @@ function test(fileName, done) {
 
           // Open and read the size of the minified output
           fs.stat(minifiedFilePath, function (err, stats) {
+            if (err) {
+              throw new Error('There was an error reading ' + minifiedFilePath);
+            }
+
             var minifiedSize = stats.size;
             var minifiedTime = new Date() - startTime;
 


### PR DESCRIPTION
In relation to #300 

There seems to be some error getting file stats on the minified file, probably due to some problem further up the pipeline, resulting in a missing file or something.

This PR just increases the visibility of the error, though you may want to dig into `err` and see if it contains any meaningful information rather than just throwing it away and exploding like this PR does.

@XhmikosR Let me know if this sheds any light on the issues you're seeing on Windows.
