### PR TITLE
Make benchmark.js cross-platform.

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
-/* jshint strict:false */
+'use strict';
 
 var fs = require('fs'),
     path = require('path'),
     exec = require('child_process').exec,
+    chalk = require('chalk'),
     Table = require('cli-table');
 
 var fileNames = [
@@ -28,34 +29,32 @@ var table = new Table({
   colWidths: [20, 25, 25, 20, 20]
 });
 
-console.log('');
-
 function toKb(size) {
   return (size / 1024).toFixed(2);
 }
 
 function redSize(size) {
-  return '\033[91m' + size + '\033[0m (' + toKb(size) + 'KB)';
+  return chalk.red.bold(size) + chalk.white(' (' + toKb(size) + ' KB)');
 }
 
 function greenSize(size) {
-  return '\033[92m' + size + '\033[0m (' + toKb(size) + 'KB)';
+  return chalk.green.bold(size) + chalk.white(' (' + toKb(size) + ' KB)');
 }
 
 function blueSavings(oldSize, newSize) {
   var savingsPercent = (1 - newSize / oldSize) * 100;
   var savings = (oldSize - newSize) / 1024;
-  return '\033[96m' + savingsPercent.toFixed(2) + '\033[0m% (' + savings.toFixed(2) + 'KB)';
+  return chalk.cyan.bold(savingsPercent.toFixed(2)) + chalk.white('% (' + savings.toFixed(2) + ' KB)');
 }
 
 function blueTime(time) {
-  return '\033[96m' + time + '\033[0mms';
+  return chalk.cyan.bold(time) + chalk.white(' ms');
 }
 
 function test(fileName, done) {
 
   if (!fileName) {
-    console.log(table.toString());
+    console.log('\n' + table.toString());
     return;
   }
 

--- a/benchmark.js
+++ b/benchmark.js
@@ -8,18 +8,20 @@ var fs = require('fs'),
     Table = require('cli-table');
 
 var fileNames = [
-  // 'es6-draft',
-  // 'eloquentjavascript',
-  'wikipedia',
-  'stackoverflow',
-  'amazon',
-  'es6-table',
-  'msn',
-  'google',
-  'newyorktimes',
   'abc',
-  'html-minifier'
+  'amazon',
+  //'eloquentjavascript',
+  //'es6-draft',
+  'es6-table',
+  'google',
+  'html-minifier',
+  'msn',
+  'newyorktimes',
+  'stackoverflow',
+  'wikipedia'
 ];
+
+fileNames = fileNames.sort().reverse();
 
 var table = new Table({
   head: ['File', 'Before', 'After', 'Savings', 'Time'],

--- a/benchmark.js
+++ b/benchmark.js
@@ -1,6 +1,9 @@
+#!/usr/bin/env node
+
 /* jshint strict:false */
 
 var fs = require('fs'),
+    path = require('path'),
     exec = require('child_process').exec,
     Table = require('cli-table');
 
@@ -25,16 +28,16 @@ var table = new Table({
 
 console.log('');
 
+function toKb(size) {
+  return (size / 1024).toFixed(2);
+}
+
 function redSize(size) {
   return '\033[91m' + size + '\033[0m (' + toKb(size) + 'KB)';
 }
 
 function greenSize(size) {
   return '\033[92m' + size + '\033[0m (' + toKb(size) + 'KB)';
-}
-
-function toKb(size) {
-  return (size / 1024).toFixed(2);
 }
 
 function blueSavings(oldSize, newSize) {
@@ -56,24 +59,31 @@ function test(fileName, done) {
 
   console.log('Processing...', fileName);
 
-  var filePath = 'benchmarks/' + fileName + '.html';
-  var minifiedFilePath = 'benchmarks/generated/' + fileName + '.min.html';
-  var gzFilePath = 'benchmarks/generated/' + fileName + '.html.gz';
-  var gzMinifiedFilePath = 'benchmarks/generated/' + fileName + '.min.html.gz';
-  var command = './cli.js ' + filePath + ' -c benchmark.conf' + ' -o ' + minifiedFilePath;
+  var filePath = path.join('benchmarks/', fileName + '.html');
+  var minifiedFilePath = path.join('benchmarks/generated/', fileName + '.min.html');
+  var gzFilePath = path.join('benchmarks/generated/', fileName + '.html.gz');
+  var gzMinifiedFilePath = path.join('benchmarks/generated/', fileName + '.min.html.gz');
+  var command = path.normalize('./cli.js') + ' ' + filePath + ' -c benchmark.conf' + ' -o ' + minifiedFilePath;
 
   // Open and read the size of the original input
   fs.stat(filePath, function (err, stats) {
+    if (err) {
+      throw new Error('There was an error reading ' + filePath);
+    }
     var originalSize = stats.size;
 
     exec('gzip --keep --force --best --stdout ' + filePath + ' > ' + gzFilePath, function () {
       // Open and read the size of the gzipped original
       fs.stat(gzFilePath, function (err, stats) {
+        if (err) {
+          throw new Error('There was an error reading ' + gzFilePath);
+        }
+
         var gzOriginalSize = stats.size;
 
         // Begin timing after gzipped fixtures have been created
         var startTime = new Date();
-        exec(command, function () {
+        exec('node ' + command, function () {
 
           // Open and read the size of the minified output
           fs.stat(minifiedFilePath, function (err, stats) {
@@ -88,6 +98,10 @@ function test(fileName, done) {
             exec('gzip --keep --force --best --stdout ' + minifiedFilePath + ' > ' + gzMinifiedFilePath, function () {
               // Open and read the size of the minified+gzipped output
               fs.stat(gzMinifiedFilePath, function (err, stats) {
+                if (err) {
+                  throw new Error('There was an error reading ' + gzMinifiedFilePath);
+                }
+
                 var gzMinifiedSize = stats.size;
                 var gzMinifiedTime = new Date() - startTime;
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "relateurl": "0.2.x"
   },
   "devDependencies": {
+    "chalk": "0.5.x",
     "cli-table": "0.3.x",
     "grunt": "0.4.x",
     "grunt-contrib-concat": "0.5.x",


### PR DESCRIPTION
Also, check for failures in all places.

This is how it looks now on Windows:

```
┌────────────────────┬─────────────────────────┬─────────────────────────┬────────────────────┬────────────────────┐
│ File               │ Before                  │ After                   │ Savings            │ Time               │
├────────────────────┼─────────────────────────┼─────────────────────────┼────────────────────┼────────────────────┤
│ html-minifier      │ 49978 (48.81KB)         │ 38611 (37.71KB)         │ 22.74% (11.10KB)   │ 204ms              │
│ + gzipped          │ 0 (0.00KB)              │ 0 (0.00KB)              │ NaN% (0.00KB)      │ 219ms              │
├────────────────────┼─────────────────────────┼─────────────────────────┼────────────────────┼────────────────────┤
│ abc                │ 93187 (91.00KB)         │ 78041 (76.21KB)         │ 16.25% (14.79KB)   │ 328ms              │
│ + gzipped          │ 0 (0.00KB)              │ 0 (0.00KB)              │ NaN% (0.00KB)      │ 328ms              │
├────────────────────┼─────────────────────────┼─────────────────────────┼────────────────────┼────────────────────┤
│ newyorktimes       │ 134565 (131.41KB)       │ 113790 (111.12KB)       │ 15.44% (20.29KB)   │ 328ms              │
│ + gzipped          │ 0 (0.00KB)              │ 0 (0.00KB)              │ NaN% (0.00KB)      │ 328ms              │
├────────────────────┼─────────────────────────┼─────────────────────────┼────────────────────┼────────────────────┤
│ google             │ 136320 (133.13KB)       │ 129327 (126.30KB)       │ 5.13% (6.83KB)     │ 828ms              │
│ + gzipped          │ 0 (0.00KB)              │ 0 (0.00KB)              │ NaN% (0.00KB)      │ 843ms              │
├────────────────────┼─────────────────────────┼─────────────────────────┼────────────────────┼────────────────────┤
│ msn                │ 160454 (156.69KB)       │ 136471 (133.27KB)       │ 14.95% (23.42KB)   │ 594ms              │
│ + gzipped          │ 0 (0.00KB)              │ 0 (0.00KB)              │ NaN% (0.00KB)      │ 610ms              │
├────────────────────┼─────────────────────────┼─────────────────────────┼────────────────────┼────────────────────┤
│ es6-table          │ 120768 (117.94KB)       │ 81968 (80.05KB)         │ 32.13% (37.89KB)   │ 375ms              │
│ + gzipped          │ 0 (0.00KB)              │ 0 (0.00KB)              │ NaN% (0.00KB)      │ 375ms              │
├────────────────────┼─────────────────────────┼─────────────────────────┼────────────────────┼────────────────────┤
│ amazon             │ 251828 (245.93KB)       │ 211598 (206.64KB)       │ 15.98% (39.29KB)   │ 797ms              │
│ + gzipped          │ 0 (0.00KB)              │ 0 (0.00KB)              │ NaN% (0.00KB)      │ 797ms              │
├────────────────────┼─────────────────────────┼─────────────────────────┼────────────────────┼────────────────────┤
│ stackoverflow      │ 205280 (200.47KB)       │ 163577 (159.74KB)       │ 20.32% (40.73KB)   │ 406ms              │
│ + gzipped          │ 0 (0.00KB)              │ 0 (0.00KB)              │ NaN% (0.00KB)      │ 406ms              │
├────────────────────┼─────────────────────────┼─────────────────────────┼────────────────────┼────────────────────┤
│ wikipedia          │ 411051 (401.42KB)       │ 390036 (380.89KB)       │ 5.11% (20.52KB)    │ 453ms              │
│ + gzipped          │ 0 (0.00KB)              │ 0 (0.00KB)              │ NaN% (0.00KB)      │ 453ms              │
└────────────────────┴─────────────────────────┴─────────────────────────┴────────────────────┴────────────────────┘
```

Fixes #300 

/CC @kangax @duncanbeevers 
