### PR TITLE
Convert binary stdin to UTF-8 after full buffer concatenation

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -163,6 +163,7 @@ cli.main(function(args, options) {
 
     var BUFSIZE = 4096;
     var buf = new Buffer(BUFSIZE);
+    var fullBuf = new Buffer(0);
     var bytesRead;
 
     while (true) { // Loop as long as stdin input is available.
@@ -194,9 +195,10 @@ cli.main(function(args, options) {
         //   *interactive* stdin input.
         break;
       }
-      original += buf.toString('utf8', 0, bytesRead);
+      fullBuf = Buffer.concat([fullBuf, buf.slice(0, bytesRead)]);
     }
 
+    original = fullBuf.toString('utf8');
   }
 
   function parseJSONOption(value) {


### PR DESCRIPTION
Previously, this script was converting each buffer to UTF-8, then concatenating UTF-8 strings. This lead to problems when partial UTF-8 bytes were cut across two buffers, resulting in invalid UTF-8 string.

BTW I strongly encourage to use a proper stream concatenation library like concat-stream, already implemented in #341. This PR is just to temporarily fix for a single issue, but as stated in #341 there are other issues with this code.
