### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,7 @@
     "Hugo Wetterberg <hugo@wetterberg.nu>",
     "Zoltan Frombach <tssajo@gmail.com>"
   ],
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/kangax/html-minifier/blob/gh-pages/LICENSE"
-  },
+  "license": "MIT",
   "bin": "./cli.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
