### PR TITLE
Fixed Incorrect Name

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,7 +255,7 @@
           HTMLMinifier is made by <a href="http://perfectionkills.com/">kangax</a>,
           using tweaked version of HTML parser by <a href="http://ejohn.org/">John Resig</a>
           (which, in its turn, is based on work of <a href="http://erik.eae.net/">Erik Arvidsson</a>).
-          Source and bugtracker are <a href="https://github.com/kangax/html-minifier">hosted on Github</a>.
+          Source and bugtracker are <a href="https://github.com/kangax/html-minifier">hosted on GitHub</a>.
         </p>
       </div>
 


### PR DESCRIPTION
Fixed spelling of GitHub. It was written as Github.
