### PR TITLE
Bump up clean-css minor version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "change-case": "2.3.x",
-    "clean-css": "3.3.x",
+    "clean-css": "3.4.x",
     "cli": "0.8.x",
     "concat-stream": "1.5.x",
     "uglify-js": "2.4.x",


### PR DESCRIPTION
clean-css 3.4.x supports Polymer mixins and variables - https://github.com/jakubpawlowicz/clean-css/issues/648

Addresses #403 
