### PR TITLE
Fix move of cli.exit(status) outside of runMinifiy

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -190,6 +190,8 @@ cli.main(function(args, options) {
         cli.error('Cannot write to output');
       }
     }
+    
+    cli.exit(status);
   }
 
   function createDirectory(path) {
@@ -345,5 +347,4 @@ cli.main(function(args, options) {
   else { // Minifying input coming from STDIN
     process.stdin.pipe(concat({ encoding: 'string' }, runMinify));
   }
-  cli.exit(status);
 });


### PR DESCRIPTION
It seems like the call to `cli.exit(status)` was unconsciously moved outside of runMinify in a merge conflict (https://github.com/kangax/html-minifier/commit/e17c9059feaa9487e4644cc144713a6944b176ab#diff-2cce40143051e25f811b56c79d619bf5) which is causing a thrown error: "ReferenceError: status is not defined"
