### PR TITLE
incorporate tests from PHPTAL

### DIFF
--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -1818,4 +1818,105 @@
     equal(minify(input, options), output);
   });
 
+  test('tests from PHPTAL', function() {
+    [
+      // trailing </p> removed by minifier, but not by PHPTAL
+      ['<p>foo bar baz', '<p>foo     \t bar\n\n\n baz</p>'],
+      ['<p>foo bar<pre>  \tfoo\t   \nbar   </pre>', '<p>foo   \t\n bar</p><pre>  \tfoo\t   \nbar   </pre>'],
+      /* needs to handle whitespace within and around <a>
+      ['<p>foo <a href="">bar </a>baz', '<p>foo <a href=""> bar </a> baz  </p>'],
+      ['<p>foo <a href="">bar </a>baz', ' <p>foo <a href=""> bar </a>baz </p>'],
+      ['<p>foo<a href=""> bar </a>baz', ' <p> foo<a href=""> bar </a>baz </p>  '],
+      ['<p>foo <a href="">bar</a> baz', ' <p> foo <a href="">bar</a> baz</p>'],
+       */
+      ['<p>foo<br>', '<p>foo <br/></p>'],
+      // PHPTAL remove whitespace after 'foo' - problematic if <span> is used as icon font
+      ['<p>foo <span></span>', '<p>foo <span></span></p>'],
+      ['<p>foo <span></span>', '<p>foo <span></span> </p>'],
+      // comments removed by minifier, but not by PHPTAL
+      ['<p>foo', '<p>foo <!-- --> </p>'],
+      ['<div>a<div>b</div>c<div>d</div>e</div>', '<div>a <div>b</div> c <div> d </div> e </div>'],
+      // unary slashes removed by minifier, but not by PHPTAL
+      ['<div><img></div>', '<div> <img/> </div>'],
+      ['<div>x <img></div>', '<div> x <img/> </div>'],
+      ['<div>x <img> y</div>', '<div> x <img/> y </div>'],
+      ['<div><img> y</div>', '<div><img/> y </div>'],
+      ['<div><button>Z</button></div>', '<div> <button>Z</button> </div>'],
+      ['<div>x <button>Z</button></div>', '<div> x <button>Z</button> </div>'],
+      ['<div>x <button>Z</button> y</div>', '<div> x <button>Z</button> y </div>'],
+      ['<div><button>Z</button> y</div>', '<div><button>Z</button> y </div>'],
+      ['<div><button>Z</button></div>', '<div> <button> Z </button> </div>'],
+      ['<div>x <button>Z</button></div>', '<div> x <button> Z </button> </div>'],
+      ['<div>x <button>Z</button> y</div>', '<div> x <button> Z </button> y </div>'],
+      ['<div><button>Z</button> y</div>', '<div><button> Z </button> y </div>'],
+      ['<script>//foo\nbar()</script>', '<script>//foo\nbar()</script>'],
+      // optional tags removed by minifier, but not by PHPTAL
+      // parser cannot handle <script/>
+      [
+        '<title></title><link><script>" ";</script><script></script><meta><style></style>',
+        '<html >\n' +
+        '<head > <title > </title > <link /> <script >" ";</script> <script>\n</script>\n' +
+        ' <meta /> <style\n' +
+        '  > </style >\n' +
+        '   </head > </html>'
+      ],
+      ['<div><p>test 123<p>456<ul><li>x</ul></div>', '<div> <p> test 123 </p> <p> 456 </p> <ul> <li>x</li> </ul> </div>'],
+      ['<div><p>test 123<pre> 456 </pre><p>x</div>', '<div> <p> test 123 </p> <pre> 456 </pre> <p> x </p> </div>'],
+      /* minifier does not assume <li> as "display: inline"
+      ['<div><ul><li><a>a </a></li><li>b </li><li>c</li></ul></div>', '<div> <ul> <li> <a> a </a> </li> <li> b </li> <li> c </li> </ul> </div>'],
+       */
+      ['<table>x<tr>x<td>foo</td>x</tr>x</table>', '<table> x <tr> x <td> foo </td> x </tr> x </table>'],
+      ['<select>x<option></option>x<optgroup>x<option></option>x</optgroup>x</select>', '<select> x <option> </option> x <optgroup> x <option> </option> x </optgroup> x </select> '],
+      /* minifier does not reorder attributes
+      ['<img src="foo" width="10" height="5" alt="x"/>', '<img width="10" height="5" src="foo" alt="x" />'],
+      ['<img alpha="1" beta="2" gamma="3"/>', '<img gamma="3" alpha="1" beta="2" />'],
+       */
+      ['<pre>\n\n\ntest</pre>', '<pre>\n\n\ntest</pre>'],
+      /* single line-break preceding <pre> is redundant, assuming <pre> is block element
+      ['<pre>test</pre>', '<pre>\ntest</pre>'],
+       */
+      // optional attribute quotes removed by minifier, but not by PHPTAL
+      ['<meta http-equiv=Content-Type content="text/plain;charset=UTF-8">', '<meta http-equiv=\'Content-Type\' content=\'text/plain;charset=UTF-8\'/>'],
+      /* minifier does not optimise <meta/> in HTML5 mode
+      ['<meta charset=utf-8>', '<meta http-equiv=\'Content-Type\' content=\'text/plain;charset=UTF-8\'/>'],
+       */
+      /* minifier does not optimise <script/> in HTML5 mode
+      [
+        '<script></script><style></style>',
+        '<script type=\'text/javascript ;charset=utf-8\'\n' +
+        'language=\'javascript\'></script><style type=\'text/css\'></style>'
+      ],
+       */
+      ['<script type="text/javascript;e4x=1"></script><script type=text/hack></script>', '<script type="text/javascript;e4x=1"></script><script type="text/hack"></script>']
+      /* trim "title" attribute value in <a>
+      [
+        '<title>Foo</title><p><a title=\"x\"href=test>x </a>xu</p><br>foo',
+        '<html> <head> <title> Foo </title> </head>\n' +
+        '<body>\n' +
+        '<p>\n' +
+        '<a title="   x " href=" test "> x </a> xu\n' +
+        '</p>\n' +
+        '<br/>\n' +
+        'foo</body> </html>  <!-- bla -->'
+      ]
+       */
+    ].forEach(function(tokens) {
+      equal(minify(tokens[1], {
+        collapseBooleanAttributes: true,
+        collapseWhitespace: true,
+        removeAttributeQuotes: true,
+        removeCDATASectionsFromCDATA: true,
+        removeComments: true,
+        removeCommentsFromCDATA: true,
+        removeEmptyAttributes: true,
+        removeOptionalTags: true,
+        removeRedundantAttributes: true,
+        removeScriptTypeAttributes: true,
+        removeStyleLinkTypeAttributes: true,
+        removeTagWhitespace: true,
+        useShortDoctype: true
+      }), tokens[0]);
+    });
+  });
+
 })(typeof exports === 'undefined' ? window : exports);


### PR DESCRIPTION
Ignored tests that:
- uses `tal:*` attributes
- evaluates PHP code
- uses `xmlns`
- uses `xml:space="preserve"`

Added comments to the ones which `html-minifier` gives different (better) output, and commented out the failed ones stating missing features.
