### PR TITLE
enable removeTagWhitespace on web version

### DIFF
--- a/assets/master.js
+++ b/assets/master.js
@@ -18,6 +18,7 @@
       collapseWhitespace:             byId('collapse-whitespace').checked,
       conservativeCollapse:           byId('conservative-collapse').checked,
       collapseBooleanAttributes:      byId('collapse-boolean-attributes').checked,
+      removeTagWhitespace:            byId('remove-tag-whitespace').checked,
       removeAttributeQuotes:          byId('remove-attribute-quotes').checked,
       removeRedundantAttributes:      byId('remove-redundant-attributes').checked,
       useShortDoctype:                byId('use-short-doctype').checked,

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
               </label>
             </li>
             <li>
-              <input type="checkbox" id="remove-tag-whitespace">
+              <input type="checkbox" id="remove-tag-whitespace" checked>
               <label for="remove-tag-whitespace">Remove space between attributes</label>
             </li>
             <li>


### PR DESCRIPTION
So even though I've added a checkbox in `index.html`, I forgot (read: didn't know) to wire the logic in `master.js` :disappointed: 

As `removeTagWhitespace` has been tested rather extensively now, this change also enables it by default in the online version.
