### PR TITLE
Allow -o from stdin

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -347,6 +347,8 @@ cli.main(function(args, options) {
 
   }
   else { // Minifying input coming from STDIN
-    process.stdin.pipe(concat({ encoding: 'string' }, runMinify));
+    process.stdin.pipe(concat({ encoding: 'string' }, function(content) {
+      runMinify(content, output);
+    }));
   }
 });


### PR DESCRIPTION
I believe this regressed during refactoring here: https://github.com/kangax/html-minifier/commit/41c6cb002f3193d711464a7a39101cea93028e38

When using make, it's preferable to do something like:

`cat input.html | html-minifier -o output.html`

Because then the output is only created on success - whereas if you do

`cat input.html | html-minifier > output.html`

You get an empty output.html on error, and make thinks everything is fine (forcing you to clean on every error).
