### PR TITLE
Throw Error not string

### DIFF
--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -243,7 +243,7 @@
       }
 
       if ( html === last ) {
-        throw 'Parse Error: ' + html;
+        throw new Error('Parse Error: ' + html);
       }
     }
 


### PR DESCRIPTION
Got bitten by the silent treatment from html-loader (another fix for the same issue https://github.com/webpack/html-loader/pull/57 )
