### PR TITLE
fix the static analysis of Webpack

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -642,17 +642,13 @@
     return text;
   }
 
-  function getModule(name, path) {
-    // try to get global reference first
-    var result = global[name];
-    if (typeof result === 'undefined' && typeof require === 'function') {
-      result = require(path);
-    }
-    return result;
-  }
-
   var minifyURLs = (function() {
-    var RelateUrl = getModule('RelateUrl', 'relateurl');
+    // try to get global reference first
+    var RelateUrl = global.RelateUrl;
+    if (typeof RelateUrl === 'undefined' && typeof require === 'function') {
+      RelateUrl = require('relateurl');
+    }
+
     if (RelateUrl && RelateUrl.relate) {
       return function(text, options) {
         try {
@@ -670,7 +666,12 @@
   })();
 
   var minifyJS = (function() {
-    var UglifyJS = getModule('UglifyJS', 'uglify-js');
+    // try to get global reference first
+    var UglifyJS = global.UglifyJS;
+    if (typeof UglifyJS === 'undefined' && typeof require === 'function') {
+      UglifyJS = require('uglify-js');
+    }
+
     if (UglifyJS && UglifyJS.minify) {
       return function(text, options) {
         try {
@@ -688,7 +689,12 @@
   })();
 
   var minifyCSS = (function() {
-    var CleanCSS = getModule('CleanCSS', 'clean-css');
+    // try to get global reference first
+    var CleanCSS = global.CleanCSS;
+    if (typeof CleanCSS === 'undefined' && typeof require === 'function') {
+      CleanCSS = require('clean-css');
+    }
+
     if (CleanCSS) {
       return function(text, options, inline) {
         try {


### PR DESCRIPTION
That's is following this [short discussion](https://github.com/kangax/html-minifier/pull/531/files/0daf110770393f079da6d6fb66576fdcc6eafd35#r56428013).
Webpack is doing a static analysis of the source files do determine the used dependencies.
Using a runtime resolution of the dependencies isn't something he can handle out of the box:

``` js
require(path);
```
