### PR TITLE
populate eslint with common rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,7 @@
   },
   "extends": "eslint:recommended",
   "rules": {
+    "block-scoped-var": "error",
     "brace-style": [
       "error",
       "stroustrup",
@@ -11,7 +12,85 @@
         "allowSingleLine": true
       }
     ],
+    "comma-spacing": "error",
+    "comma-style": [
+      "error",
+      "last"
+    ],
+    "curly": "error",
+    "eol-last": "error",
+    "eqeqeq": "error",
+    "indent": [
+      "error",
+      2,
+      {
+        "SwitchCase": 1,
+        "VariableDeclarator": 2
+      }
+    ],
+    "key-spacing": [
+      "error",
+      {
+        "beforeColon": false,
+        "afterColon": true,
+        "mode": "minimum"
+      }
+    ],
+    "keyword-spacing": "error",
+    "new-parens": "error",
+    "no-array-constructor": "error",
     "no-console": "off",
-    "no-throw-literal": "error"
+    "no-floating-decimal": "error",
+    "no-lone-blocks": "error",
+    "no-lonely-if": "error",
+    "no-multiple-empty-lines": "error",
+    "no-multi-spaces": "error",
+    "no-new-object": "error",
+    "no-path-concat": "error",
+    "no-process-env": "error",
+    "no-return-assign": "error",
+    "no-self-compare": "error",
+    "no-sequences": "error",
+    "no-spaced-func": "error",
+    "no-throw-literal": "error",
+    "no-trailing-spaces": "error",
+    "no-unused-expressions": "error",
+    "no-useless-call": "error",
+    "no-useless-concat": "error",
+    "no-void": "error",
+    "object-curly-spacing": [
+      "error",
+      "always"
+    ],
+    "operator-assignment": [
+      "error",
+      "always"
+    ],
+    "quote-props": [
+      "error",
+      "as-needed"
+    ],
+    "quotes": [
+      "error",
+      "single"
+    ],
+    "semi": "error",
+    "semi-spacing": "error",
+    "space-before-blocks": "error",
+    "space-unary-ops": "error",
+    "spaced-comment": [
+      "error",
+      "always",
+      {
+        "markers": [
+          "!"
+        ]
+      }
+    ],
+    "wrap-iife": [
+      "error",
+      "inside"
+    ],
+    "yoda": "error"
   }
 }

--- a/assets/master.js
+++ b/assets/master.js
@@ -32,7 +32,7 @@
       minifyJS:                       byId('minify-js').checked,
       processScripts:                 byId('minify-js-templates').checked ? byId('minify-js-templates-type').value : false,
       minifyCSS:                      byId('minify-css').checked,
-      minifyURLs:                     byId('minify-urls').checked ? { site:byId('minify-urls-siteurl').value } : false,
+      minifyURLs:                     byId('minify-urls').checked ? { site: byId('minify-urls-siteurl').value } : false,
       lint:                           byId('use-htmllint').checked ? new HTMLLint() : null,
       maxLineLength:                  parseInt(byId('max-line-length').value, 10)
     };
@@ -113,6 +113,6 @@ _gaq.push(['_trackPageview']);
   var ga = document.createElement('script');
   ga.type = 'text/javascript';
   ga.async = true;
-  ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+  ga.src = (document.location.protocol === 'https:' ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
   document.getElementsByTagName('head')[0].appendChild(ga);
 })();

--- a/benchmark.js
+++ b/benchmark.js
@@ -277,7 +277,7 @@ run(fileNames.map(function (fileName) {
             }
           });
         }).end(querystring.stringify({
-          code_type:'html',
+          code_type: 'html',
           verbose: 1,
           html_level: 1,
           minimize_style: 1,

--- a/cli.js
+++ b/cli.js
@@ -176,6 +176,7 @@ cli.main(function(args, options) {
     if (minified !== null) {
       // Write the output
       try {
+        // eslint-disable-next-line eqeqeq
         if (output != null) {
           fs.writeFileSync(path.resolve(output), minified);
         }

--- a/dist/htmlminifier.js
+++ b/dist/htmlminifier.js
@@ -340,7 +340,7 @@
           name: name,
           value: value,
           customAssign: customAssign || '=',
-          customOpen:  customOpen || '',
+          customOpen: customOpen || '',
           customClose: customClose || '',
           quote: quote || ''
         };
@@ -448,8 +448,8 @@
     }
 
     var elems = [],
-      documentElement = doc.documentElement ||
-        doc.getDocumentElement && doc.getDocumentElement();
+        documentElement = doc.documentElement ||
+          doc.getDocumentElement && doc.getDocumentElement();
 
     // If we're dealing with an empty document then we
     // need to pre-populate it with the HTML document structure
@@ -511,7 +511,7 @@
       chars: function( text ) {
         curParentNode.appendChild( doc.createTextNode( text ) );
       },
-      comment: function( /*text*/ ) {
+      comment: function( /* text */ ) {
         // create comment node
       },
       ignore: function( /* text */ ) {
@@ -1698,7 +1698,7 @@
     return minify(value, options);
   };
 
-}(typeof exports === 'undefined' ? this : exports));
+})(typeof exports === 'undefined' ? this : exports);
 
 /*!
  * HTMLLint (to be used in conjunction with HTMLMinifier)

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1164,4 +1164,4 @@
     return minify(value, options);
   };
 
-}(typeof exports === 'undefined' ? this : exports));
+})(typeof exports === 'undefined' ? this : exports);

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -335,7 +335,7 @@
           name: name,
           value: value,
           customAssign: customAssign || '=',
-          customOpen:  customOpen || '',
+          customOpen: customOpen || '',
           customClose: customClose || '',
           quote: quote || ''
         };
@@ -443,8 +443,8 @@
     }
 
     var elems = [],
-      documentElement = doc.documentElement ||
-        doc.getDocumentElement && doc.getDocumentElement();
+        documentElement = doc.documentElement ||
+          doc.getDocumentElement && doc.getDocumentElement();
 
     // If we're dealing with an empty document then we
     // need to pre-populate it with the HTML document structure
@@ -506,7 +506,7 @@
       chars: function( text ) {
         curParentNode.appendChild( doc.createTextNode( text ) );
       },
-      comment: function( /*text*/ ) {
+      comment: function( /* text */ ) {
         // create comment node
       },
       ignore: function( /* text */ ) {

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -777,21 +777,21 @@
     output = '<div><pRe>$foo = "baz";</pRe></div>';
     equal(minify(input, { collapseWhitespace: true, caseSensitive: true }), output);
 
-    input = '<script type=\"text\/javascript\">var = \"hello\";<\/script>\r\n\r\n\r\n'               +
-             '<style type=\"text\/css\">#foo { color: red;        }          <\/style>\r\n\r\n\r\n'  +
-             '<div>\r\n  <div>\r\n    <div><!-- hello -->\r\n      <div>'                            +
-             '<!--! hello -->\r\n        <div>\r\n          <div class=\"\">\r\n\r\n            '    +
-             '<textarea disabled=\"disabled\">     this is a textarea <\/textarea>\r\n          '    +
-             '<\/div>\r\n        <\/div>\r\n      <\/div>\r\n    <\/div>\r\n  <\/div>\r\n<\/div>'    +
-             '<pre>       \r\nxxxx<\/pre><span>x<\/span> <span>Hello<\/span> <b>billy<\/b>     \r\n' +
-             '<input type=\"text\">\r\n<textarea><\/textarea>\r\n<pre><\/pre>';
-    output = '<script type="text/javascript">var = "hello";</script>'                                +
-             '<style type="text/css">#foo { color: red;        }</style>'                            +
-             '<div><div><div>'                                                                       +
-             '<!-- hello --><div><!--! hello --><div><div class="">'                                 +
-             '<textarea disabled="disabled">     this is a textarea </textarea>'                     +
-             '</div></div></div></div></div></div>'                                                  +
-             '<pre>       \r\nxxxx</pre><span>x</span> <span>Hello</span> <b>billy</b> '             +
+    input = '<script type=\"text\/javascript\">var = \"hello\";<\/script>\r\n\r\n\r\n' +
+            '<style type=\"text\/css\">#foo { color: red;        }          <\/style>\r\n\r\n\r\n' +
+            '<div>\r\n  <div>\r\n    <div><!-- hello -->\r\n      <div>' +
+            '<!--! hello -->\r\n        <div>\r\n          <div class=\"\">\r\n\r\n            ' +
+            '<textarea disabled=\"disabled\">     this is a textarea <\/textarea>\r\n          ' +
+            '<\/div>\r\n        <\/div>\r\n      <\/div>\r\n    <\/div>\r\n  <\/div>\r\n<\/div>' +
+            '<pre>       \r\nxxxx<\/pre><span>x<\/span> <span>Hello<\/span> <b>billy<\/b>     \r\n' +
+            '<input type=\"text\">\r\n<textarea><\/textarea>\r\n<pre><\/pre>';
+    output = '<script type="text/javascript">var = "hello";</script>' +
+             '<style type="text/css">#foo { color: red;        }</style>'+
+             '<div><div><div>' +
+             '<!-- hello --><div><!--! hello --><div><div class="">' +
+             '<textarea disabled="disabled">     this is a textarea </textarea>' +
+             '</div></div></div></div></div></div>' +
+             '<pre>       \r\nxxxx</pre><span>x</span> <span>Hello</span> <b>billy</b> ' +
              '<input type="text"><textarea></textarea><pre></pre>';
     equal(minify(input, { collapseWhitespace: true }), output);
 


### PR DESCRIPTION
From https://github.com/kangax/html-minifier/commit/560e109e7f3fba6882b08c9d760404fc28754362#commitcomment-16783499

@XhmikosR I've incorporated the rules from https://github.com/giakki/uncss/blob/deps/.eslintrc - the omitted ones are almost all due to being included in the `recommended` set.
