### PR TITLE
Custom JS minifier for es6 (or coffee, or whatever)

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -3,8 +3,9 @@
 var CleanCSS = require('clean-css');
 var HTMLParser = require('./htmlparser').HTMLParser;
 var RelateUrl = require('relateurl');
-var UglifyJS = require('uglify-js');
 var utils = require('./utils');
+
+var defaultJSMinifier = "uglify-js";
 
 var log;
 if (typeof window !== 'undefined' && typeof console !== 'undefined' && typeof console.log === 'function') {
@@ -635,7 +636,8 @@ function minifyURLs(text, options) {
 
 function minifyJS(text, options) {
   try {
-    return UglifyJS.minify(text, options).code;
+    var Minifier = require( options.minifier ? options.minifier : defaultJSMinifier );
+    return Minifier.minify(text, options).code;
   }
   catch (err) {
     log(err);

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -3,9 +3,8 @@
 var CleanCSS = require('clean-css');
 var HTMLParser = require('./htmlparser').HTMLParser;
 var RelateUrl = require('relateurl');
+var UglifyJS = require('uglify-js');
 var utils = require('./utils');
-
-var defaultJSMinifier = "uglify-js";
 
 var log;
 if (typeof window !== 'undefined' && typeof console !== 'undefined' && typeof console.log === 'function') {
@@ -636,8 +635,12 @@ function minifyURLs(text, options) {
 
 function minifyJS(text, options) {
   try {
-    var Minifier = require( options.minifier ? options.minifier : defaultJSMinifier );
-    return Minifier.minify(text, options).code;
+	if( options.minifier ){
+      return options.minifier.call( this, text, options );
+	}
+	else {
+      return UglifyJS.minify(text, options).code;
+	}
   }
   catch (err) {
     log(err);


### PR DESCRIPTION
I need to support es6 templates (backtick strings).  By default uglify-js doesn't support this, although there's a harmony branch.  I'd like to swap in a custom minifier.

Dropping in arbitrary minifiers is hard because the function calls might not match.  My solution is to add a "minifier" option to the minifyJS parameter, which is a function that can provide its own dependencies and call structure.  So the call looks like

``` js
htmlmin({
    collapseWhitespace: true,
    removeComments: true,
    minifyJS: {
        minifier: function( text, options ){
            var uglify = require( "uglify-js" );
            return uglify.minify(text, options).code;
        }
    },
    minifyCSS: true
});

```

and omitting the parameter leaves the default behavior.

v 1.3.1
