### PR TITLE
Feature remove chunk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /benchmarks/generated
 /node_modules/
 /npm-debug.log
+/nbproject/

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -703,6 +703,10 @@ function minify(value, options, partialMarkup) {
     return token;
   });
 
+  // Remove specific comment chunks. Usefull to delete markup that isn't wanted
+  // in dist(ex: browsersync or livereload)
+  value = value.replace(/<!-- htmlmin:remove -->[\s\S]*?<!-- htmlmin:remove -->/g, '');
+
   var customFragments = (options.ignoreCustomFragments || [
     /<%[\s\S]*?%>/,
     /<\?[\s\S]*?\?>/

--- a/test.js
+++ b/test.js
@@ -11,7 +11,8 @@ testrunner.run({
   code: './src/htmlminifier.js',
   tests: [
     './tests/lint.js',
-    './tests/minifier.js'
+    './tests/minifier.js',
+    './tests/remove.js'
   ],
   maxBlockDuration: 5000
 }, function(err, report) {

--- a/tests/remove.js
+++ b/tests/remove.js
@@ -1,0 +1,34 @@
+/* global minify */
+'use strict';
+
+if (typeof minify === 'undefined') {
+  self.minify = require('html-minifier').minify;
+}
+
+var input, output;
+
+test('removing comment chunks', function () {
+  input = '<!-- htmlmin:remove --><!-- htmlmin:remove -->';
+  equal(minify(input), '');
+
+  input = '<!-- htmlmin:remove -->FOOBAR<!-- htmlmin:remove -->';
+  equal(minify(input), '');
+
+  input = '' +
+          '<div class="wrapper">\n' +
+          '  <p> ignored </p>\n' +
+          '  <!-- htmlmin:remove -->\n' +
+          '    <div class="removed" style="color: red">\n' +
+          '      removed <span> <input disabled/> chunk </span>\n' +
+          '    </div>\n' +
+          '  <!-- htmlmin:remove -->\n' +
+          '</div>';
+  output = '' +
+          '<div class="wrapper">\n' +
+          '  <p> ignored </p>\n' +
+          // Note there's two spaces that linger before our <!-- htmlmin:remove -->
+          '  \n' +
+          '</div>';
+
+  equal(minify(input), output);
+});


### PR DESCRIPTION
Added the ability to specify chunks of markup to delete. Useful for deleting development only scripts(ex: BrowserSync).

Input:

```
<p>Stays put</p>
<!-- htmlmin:remove -->
<script id="__bs__">
/* This script tag will be removed entirely */
</script>
<!-- htmlmin:remove-->
<script type="text/javascript" src="app/app.module.js"></script>
```

Output:

```
<p>Stays put</p>
<script type="text/javascript" src="app/app.module.js"></script>
```
