### PR TITLE
sychronise qunit version for node and web

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,7 +68,6 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-browserify');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-eslint');
-  require('time-grunt')(grunt);
 
   var phantomjs = require('grunt-lib-phantomjs').init(grunt);
   var webErrors;

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,6 +49,21 @@ module.exports = function(grunt) {
       htmlminifier: ['./tests/minifier', 'tests/index.html']
     },
 
+    replace: {
+      './index.html': [
+        /(<h1>.*?<span>).*?(<\/span><\/h1>)/,
+        '$1(v<%= pkg.version %>)$2'
+      ],
+      './tests/index.html': [
+        /("[^"]+\/qunit-)[0-9\.]+?(\.(?:css|js)")/g,
+        '$1<%= pkg.devDependencies.qunitjs %>$2'
+      ],
+      './tests/lint-tests.html': [
+        /("[^"]+\/qunit-)[0-9\.]+?(\.(?:css|js)")/g,
+        '$1<%= pkg.devDependencies.qunitjs %>$2'
+      ]
+    },
+
     uglify: {
       options: {
         banner: '<%= banner %>',
@@ -114,16 +129,16 @@ module.exports = function(grunt) {
     });
   });
 
-  grunt.registerTask('update-html', function() {
-    var pattern = /(<h1>.*?<span>).*?(<\/span><\/h1>)/;
-    var path = './index.html';
+  grunt.registerMultiTask('replace', function() {
+    var pattern = this.data[0];
+    var path = this.target;
     var html = grunt.file.read(path);
-    html = html.replace(pattern, '$1(v' + grunt.config('pkg.version') + ')$2');
+    html = html.replace(pattern, this.data[1]);
     grunt.file.write(path, html);
   });
 
   grunt.registerTask('dist', [
-    'update-html',
+    'replace',
     'browserify',
     'uglify'
   ]);

--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
     "lzma": "2.3.x",
     "minimize": "1.8.x",
     "progress": "1.1.x",
-    "qunit": "0.9.x",
-    "time-grunt": "1.3.x"
+    "qunit": "0.9.x"
   },
   "files": [
     "src",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "lzma": "2.3.x",
     "minimize": "1.8.x",
     "progress": "1.1.x",
-    "qunitjs": "1.23.x"
+    "qunitjs": "1.23.0"
   },
   "files": [
     "src",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "lzma": "2.3.x",
     "minimize": "1.8.x",
     "progress": "1.1.x",
-    "qunit": "0.9.x"
+    "qunitjs": "1.23.x"
   },
   "files": [
     "src",

--- a/test.js
+++ b/test.js
@@ -1,26 +1,18 @@
 'use strict';
 
-var testrunner = require('qunit');
-
-testrunner.options.log.summary = true;
-testrunner.options.log.tests = false;
-testrunner.options.log.assertions = false;
-
-testrunner.run({
-  deps: ['./src/htmlparser.js', './src/htmllint.js'],
-  code: './src/htmlminifier.js',
-  tests: [
-    './tests/lint.js',
-    './tests/minifier.js'
-  ],
-  maxBlockDuration: 5000
-}, function(err, report) {
-  if (report.failed > 0) {
-    process.on('exit', function() {
-      process.exit(1);
-    });
+function load(path) {
+  var obj = require(path);
+  for (var key in obj) {
+    global[key] = obj[key];
   }
-  if (err) {
-    console.log(err);
-  }
+  return obj;
+}
+
+load('.');
+load('./src/htmllint.js');
+var QUnit = load('qunitjs');
+QUnit.done(function(data) {
+  process.send(data);
 });
+require(process.argv[2]);
+QUnit.load();


### PR DESCRIPTION
Previously we use `qunit` which is locked to QUnit 1.10.0, whereas on the web we always use the latest version (currently 1.23.0).

This PR switches to `qunitjs` which is more direct, and have `grunt` make sure the web tests uses the same QUnit version as the node tests as well.

Also removing unnecessary dependencies - managed to cut down by 10 modules.
