### PR TITLE
manually manage benchmark dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,3 @@ branches:
 
 matrix:
   fast_finish: true
-
-install: npm install --no-optional

--- a/benchmark.js
+++ b/benchmark.js
@@ -2,6 +2,24 @@
 
 'use strict';
 
+var packages = require('./package.json').benchmarkDependencies;
+packages = Object.keys(packages).map(function(name) {
+  return name + '@' + packages[name];
+});
+packages.unshift('install');
+var installed = require('child_process').spawnSync('npm', packages, {
+  encoding: 'utf-8',
+  shell: true
+});
+if (installed.error) {
+  throw installed.error;
+}
+else if (installed.status) {
+  console.log(installed.stdout);
+  console.error(installed.stderr);
+  process.exit(installed.status);
+}
+
 var brotli = require('brotli'),
     chalk = require('chalk'),
     fork = require('child_process').fork,

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "phantomjs-prebuilt": "2.1.x",
     "qunitjs": "1.x"
   },
-  "optionalDependencies": {
+  "benchmarkDependencies": {
     "brotli": "1.2.x",
     "chalk": "1.1.x",
     "cli-table": "0.3.x",


### PR DESCRIPTION
ideally we want something like optionalDevDependencies, but npm doesn't have such functionality
