### PR TITLE
expose options.log instead of handling internally

### DIFF
--- a/assets/master.css
+++ b/assets/master.css
@@ -29,9 +29,6 @@ button { font-weight: bold; width: 100px; }
 .controls a { margin-left: 0.1em; }
 .controls a:focus, .controls a:hover { text-decoration: none; }
 
-.deprecated-element, .deprecated-attribute { color: red; }
-.presentational-element, .presentational-attribute, .inaccessible-attribute, .repeating-attribute { color: #FF8C00; }
-
 .unsafe { color: #f33; }
 
 iframe { position: absolute; top: 10px; right: 10px; }

--- a/assets/master.js
+++ b/assets/master.js
@@ -15,8 +15,12 @@
     [].forEach.call(byId('options').getElementsByTagName('input'), fn);
   }
 
+  function log(message) {
+    console.log(message);
+  }
+
   function getOptions() {
-    var options = {};
+    var options = { log: log };
     forEachOption(function(element) {
       var key = element.id;
       var value;


### PR DESCRIPTION
Currently when `sort*` is used, minification time is reported twice.

This also paves way for #11. Undocumented for now.
