### PR TITLE
workaround require() bug for Node.js 0.10

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -30,7 +30,7 @@
 var changeCase = require('change-case');
 var fs = require('fs');
 var info = require('./package.json');
-var minify = require('.').minify;
+var minify = require('./' + info.main).minify;
 var path = require('path');
 var program = require('commander');
 


### PR DESCRIPTION
`require('.')` does not resolve according to directory rules in Node.js 0.10

Since we test for and support that version of Node.js, might as well use the explicit path and call it a day.
