### PR TITLE
Add link to Express middleware plugin to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See [corresponding blog post](http://perfectionkills.com/experimenting-with-html
 
 [Test suite is available online](http://kangax.github.io/html-minifier/tests/).
 
-Also see corresponding [Ruby wrapper](https://github.com/stereobooster/html_minifier), and for Node.js, [Grunt plugin](https://github.com/gruntjs/grunt-contrib-htmlmin), [Gulp module](https://github.com/jonschlinkert/gulp-htmlmin), and [Koa middleware wrapper](https://github.com/koajs/html-minifier).
+Also see corresponding [Ruby wrapper](https://github.com/stereobooster/html_minifier), and for Node.js, [Grunt plugin](https://github.com/gruntjs/grunt-contrib-htmlmin), [Gulp module](https://github.com/jonschlinkert/gulp-htmlmin), [Koa middleware wrapper](https://github.com/koajs/html-minifier) and [Express middleware wrapper](https://github.com/melonmanchan/express-minify-html).
 
 For lint-like capabilities take a look at [HTMLLint](https://github.com/kangax/html-lint).
 


### PR DESCRIPTION
Hi!

Shameless self-plug here, but I created an Express middleware around your compressor a while back. If it's up to your standards, I thought it'd be cool to link to it in the README, like with the Koa one. Take care!
