### PR TITLE
Added --file-ext feature

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -220,7 +220,7 @@ function processDirectory(inputDir, outputDir, fileExt) {
       files.forEach(function(file) {
         var inputFile = path.join(inputDir, file);
         var outputFile = path.join(outputDir, file);
-        if ((fileExt)? path.extname(file) === '.'+fileExt:true) {
+        if ((fileExt) ? path.extname(file) === '.'+fileExt : true) {
           fs.readFile(inputFile, { encoding: 'utf8' }, function(err, data) {
             if (!err) {
               var minified;

--- a/cli.js
+++ b/cli.js
@@ -107,6 +107,7 @@ var mainOptions = {
   customAttrSurround: ['Arrays of regex\'es that allow to support custom attribute surround expressions (e.g. <input {{#if value}}checked="checked"{{/if}}>)', parseJSONRegExpArray],
   customEventAttributes: ['Arrays of regex\'es that allow to support custom event attributes for minifyJS (e.g. ng-click)', parseJSONRegExpArray],
   decodeEntities: 'Use direct Unicode characters whenever possible',
+
   html5: 'Parse input according to HTML5 specifications',
   ignoreCustomComments: ['Array of regex\'es that allow to ignore certain comments, when matched', parseJSONRegExpArray],
   ignoreCustomFragments: ['Array of regex\'es that allow to ignore certain fragments, when matched (e.g. <?php ... ?>, {{ ... }})', parseJSONRegExpArray],
@@ -187,6 +188,7 @@ program.option('-c --config-file <file>', 'Use config file', function(configPath
 });
 program.option('--input-dir <dir>', 'Specify an input directory');
 program.option('--output-dir <dir>', 'Specify an output directory');
+program.option('--file-ext <text>', 'Specify an extension to be read, ex: html');
 var content;
 program.arguments('[files...]').action(function(files) {
   content = files.map(readFile).join('');
@@ -206,7 +208,7 @@ function createOptions() {
   return options;
 }
 
-function processDirectory(inputDir, outputDir) {
+function processDirectory(inputDir, outputDir, fileExt) {
   fs.readdir(inputDir, function(err, files) {
     if (err) {
       fatal('Cannot read directory ' + inputDir + '\n' + err.message);
@@ -218,6 +220,8 @@ function processDirectory(inputDir, outputDir) {
       files.forEach(function(file) {
         var inputFile = path.join(inputDir, file);
         var outputFile = path.join(outputDir, file);
+        console.log(file+" "+path.extname(file)+" "+"."+fileExt);
+        if((fileExt)?path.extname(file) === "."+fileExt:true)
         fs.readFile(inputFile, { encoding: 'utf8' }, function(err, data) {
           if (!err) {
             var minified;
@@ -234,7 +238,7 @@ function processDirectory(inputDir, outputDir) {
             });
           }
           else if (err.code === 'EISDIR') {
-            processDirectory(inputFile, outputFile);
+            processDirectory(inputFile, outputFile, fileExt);
           }
           else {
             fatal('Cannot read ' + inputFile + '\n' + err.message);
@@ -258,6 +262,7 @@ function writeMinify() {
 
 var inputDir = program.inputDir;
 var outputDir = program.outputDir;
+var fileExt = program.fileExt;
 if (inputDir || outputDir) {
   if (!inputDir) {
     fatal('The option output-dir needs to be used with the option input-dir. If you are working with a single file, use -o.');
@@ -265,7 +270,7 @@ if (inputDir || outputDir) {
   else if (!outputDir) {
     fatal('You need to specify where to write the output files with the option --output-dir');
   }
-  processDirectory(inputDir, outputDir);
+  processDirectory(inputDir, outputDir, fileExt);
 }
 // Minifying one or more files specified on the CMD line
 else if (typeof content === 'string') {

--- a/cli.js
+++ b/cli.js
@@ -220,7 +220,6 @@ function processDirectory(inputDir, outputDir, fileExt) {
       files.forEach(function(file) {
         var inputFile = path.join(inputDir, file);
         var outputFile = path.join(outputDir, file);
-        console.log(file+" "+path.extname(file)+" "+"."+fileExt);
         if((fileExt)?path.extname(file) === "."+fileExt:true)
         fs.readFile(inputFile, { encoding: 'utf8' }, function(err, data) {
           if (!err) {

--- a/cli.js
+++ b/cli.js
@@ -220,29 +220,30 @@ function processDirectory(inputDir, outputDir, fileExt) {
       files.forEach(function(file) {
         var inputFile = path.join(inputDir, file);
         var outputFile = path.join(outputDir, file);
-        if((fileExt)?path.extname(file) === "."+fileExt:true)
-        fs.readFile(inputFile, { encoding: 'utf8' }, function(err, data) {
-          if (!err) {
-            var minified;
-            try {
-              minified = minify(data, createOptions());
-            }
-            catch (e) {
-              fatal('Minification error on ' + inputFile + '\n' + e.message);
-            }
-            fs.writeFile(outputFile, minified, { encoding: 'utf8' }, function(err) {
-              if (err) {
-                fatal('Cannot write ' + outputFile + '\n' + err.message);
+        if ((fileExt)? path.extname(file) === '.'+fileExt:true) {
+          fs.readFile(inputFile, { encoding: 'utf8' }, function(err, data) {
+            if (!err) {
+              var minified;
+              try {
+                minified = minify(data, createOptions());
               }
-            });
-          }
-          else if (err.code === 'EISDIR') {
-            processDirectory(inputFile, outputFile, fileExt);
-          }
-          else {
-            fatal('Cannot read ' + inputFile + '\n' + err.message);
-          }
-        });
+              catch (e) {
+                fatal('Minification error on ' + inputFile + '\n' + e.message);
+              }
+              fs.writeFile(outputFile, minified, { encoding: 'utf8' }, function(err) {
+                if (err) {
+                  fatal('Cannot write ' + outputFile + '\n' + err.message);
+                }
+              });
+            }
+            else if (err.code === 'EISDIR') {
+              processDirectory(inputFile, outputFile, fileExt);
+            }
+            else {
+              fatal('Cannot read ' + inputFile + '\n' + err.message);
+            }
+          });
+        }
       });
     });
   });

--- a/cli.js
+++ b/cli.js
@@ -220,7 +220,7 @@ function processDirectory(inputDir, outputDir, fileExt) {
       files.forEach(function(file) {
         var inputFile = path.join(inputDir, file);
         var outputFile = path.join(outputDir, file);
-        if ((fileExt) ? path.extname(file) === '.'+fileExt : true) {
+        if (fileExt ? path.extname(file) === '.' + fileExt : true) {
           fs.readFile(inputFile, { encoding: 'utf8' }, function(err, data) {
             if (!err) {
               var minified;


### PR DESCRIPTION
Due to command-line does parsing of all files and it´s recursive, gave me a problem of when I have images or whatever other type of file.
I want to filter and only have html extension being parsed by html-minifier, this is the feature I wanted and I created.

Thanks a lot for this project, hope you guys like my contribution.
