### PR TITLE
trailing whitespace removal sometimes remove inter-attribute whitespace instead

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -90,7 +90,7 @@ module.exports = function(grunt) {
 
   grunt.loadNpmTasks('grunt-browserify');
   grunt.loadNpmTasks('grunt-contrib-uglify');
-  grunt.loadNpmTasks('grunt-eslint');
+  grunt.loadNpmTasks('gruntify-eslint');
 
   function report(type, details) {
     grunt.log.writeln(type + ' completed in ' + details.runtime + 'ms');

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "grunt": "1.0.x",
     "grunt-browserify": "5.0.x",
     "grunt-contrib-uglify": "2.0.x",
-    "grunt-eslint": "19.0.x",
+    "gruntify-eslint": "3.1.x",
     "phantomjs-prebuilt": "2.1.x",
     "qunitjs": "2.x"
   },

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1138,7 +1138,11 @@ function minify(value, options, partialMarkup) {
           if (prevTag) {
             if (prevTag === '/nobr' || prevTag === 'wbr') {
               if (/^\s/.test(text)) {
-                trimTrailingWhitespace(buffer.length - 2, 'br');
+                var tagIndex = buffer.length - 1;
+                while (tagIndex > 0 && buffer[tagIndex].lastIndexOf('<' + prevTag) !== 0) {
+                  tagIndex--;
+                }
+                trimTrailingWhitespace(tagIndex - 1, 'br');
               }
             }
             else if (inlineTextTags(prevTag.charAt(0) === '/' ? prevTag.slice(1) : prevTag)) {


### PR DESCRIPTION
Affects `</nobr>` and `<wbr>` in particular.
