### PR TITLE
add customFragmentsInScripts option

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -865,6 +865,12 @@ function minify(value, options, partialMarkup) {
     });
   }
 
+  function restoreCustomFragments(text) {
+    return text.replace(uidPattern, function(match, prefix, index) {
+      return ignoredCustomMarkupChunks[+index][0];
+    });
+  }
+
   var customFragments = options.ignoreCustomFragments.map(function(re) {
     return re.source;
   });
@@ -878,12 +884,18 @@ function minify(value, options, partialMarkup) {
         var minifyCSS = options.minifyCSS;
         if (minifyCSS) {
           options.minifyCSS = function(text) {
+            if (options.preserveCustomFragmentsInStyle) {
+              text = restoreCustomFragments(text);
+            }
             return minifyCSS(escapeFragments(text));
           };
         }
         var minifyJS = options.minifyJS;
         if (minifyJS) {
           options.minifyJS = function(text, inline) {
+            if (options.preserveCustomFragmentsInScripts) {
+              text = restoreCustomFragments(text);
+            }
             return minifyJS(escapeFragments(text), inline);
           };
         }

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -1989,6 +1989,13 @@ QUnit.test('minification of scripts with custom fragments', function(assert) {
   output = '<script>function f(){return"<?php ?>"}</script>';
   assert.equal(minify(input, { minifyJS: true }), output);
   assert.equal(minify(input, { collapseWhitespace: true, minifyJS: true }), output);
+
+  input = '<script>function a() {\n    console.log( "<% ... %>" )\n}</script>';
+  output = '<script>function a(){console.log("<% ... %>")}</script>';
+  assert.equal(minify(input, { minifyJS: true, preserveCustomFragmentsInScripts: true }), output);
+
+  input = '<script>function a() { b() \n<% ... %>\n a()}</script>';
+  assert.equal(minify(input, { minifyJS: true, preserveCustomFragmentsInScripts: true }), input);
 });
 
 QUnit.test('event minification', function(assert) {


### PR DESCRIPTION
It leads to an issue with following html fragment:

``` html
<script>
function a() {
  b()
  <?php if (false): ?>
    c()
  <?php endif; ?>
}
</script>
```

After minified, it becomes:

``` html
<script>function a(){b(),}</script>
```

The trailing comma leads to a syntax error.

The only method I found is to prevent minifying javascripts when there's a customFragment inside the script tag.
