### PR TITLE
respect line breaks around custom fragments

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -888,7 +888,9 @@ function minify(value, options, partialMarkup) {
       }
       var token = uidAttr + ignoredCustomMarkupChunks.length;
       ignoredCustomMarkupChunks.push(match);
-      return '\t' + token + '\t';
+      var prefix = /^\s*\n/.test(match) ? '\n' : '\t';
+      var postfix = /\n\s*$/.test(match) ? '\n' : '\t';
+      return prefix + token + postfix;
     });
   }
 

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -1633,6 +1633,13 @@ QUnit.test('Ignore custom fragments', function(assert) {
     ignoreCustomFragments: reFragments
   }), output);
 
+  input = '<script>//\r\n<% ... %></script>';
+  output = '<script>\r\n<% ... %></script>';
+  assert.equal(minify(input, {
+    minifyJS: true,
+    ignoreCustomFragments: reFragments,
+  }), output);
+
   input = '{{ if foo? }}\r\n  <div class="bar">\r\n    ...\r\n  </div>\r\n{{ end \n}}';
   output = '{{ if foo? }}<div class="bar">...</div>{{ end }}';
   assert.equal(minify(input, {}), input);


### PR DESCRIPTION
This PR aims to fix the same issue with #714 

The issue still exists after setting `preserveLineBreaks` option.

``` html
<script>//
<% ... %>
</script>
```

Expected:

``` html
<script>
<% ... %>
</script>
```

Actual:

``` html
<script></script>
```
