### PR TITLE
#722: introduce `collapseCustomFragments` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ How does HTMLMinifier compare to other solutions — [HTML Minifier from Will Pe
 | `collapseBooleanAttributes`    | [Omit attribute values from boolean attributes](http://perfectionkills.com/experimenting-with-html-minifier/#collapse_boolean_attributes) | `false` |
 | `collapseInlineTagWhitespace`  | Don't leave any spaces between `display:inline;` elements when collapsing. Must be used in conjunction with `collapseWhitespace=true` | `false` |
 | `collapseWhitespace`           | [Collapse white space that contributes to text nodes in a document tree](http://perfectionkills.com/experimenting-with-html-minifier/#collapse_whitespace) | `false` |
+| `collapseCustomFragments`      | Collapse white space around `ignoreCustomFragments`. | `false` |
 | `conservativeCollapse`         | Always collapse to 1 space (never remove it entirely). Must be used in conjunction with `collapseWhitespace=true` | `false` |
 | `customAttrAssign`             | Arrays of regex'es that allow to support custom attribute assign expressions (e.g. `'<div flex?="{{mode != cover}}"></div>'`) | `[ ]` |
 | `customAttrCollapse`           | Regex that specifies custom attribute to strip newlines from (e.g. `/ng-class/`) | |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ How does HTMLMinifier compare to other solutions — [HTML Minifier from Will Pe
 | `collapseBooleanAttributes`    | [Omit attribute values from boolean attributes](http://perfectionkills.com/experimenting-with-html-minifier/#collapse_boolean_attributes) | `false` |
 | `collapseInlineTagWhitespace`  | Don't leave any spaces between `display:inline;` elements when collapsing. Must be used in conjunction with `collapseWhitespace=true` | `false` |
 | `collapseWhitespace`           | [Collapse white space that contributes to text nodes in a document tree](http://perfectionkills.com/experimenting-with-html-minifier/#collapse_whitespace) | `false` |
-| `collapseCustomFragments`      | Collapse white space around `ignoreCustomFragments`. | `false` |
 | `conservativeCollapse`         | Always collapse to 1 space (never remove it entirely). Must be used in conjunction with `collapseWhitespace=true` | `false` |
 | `customAttrAssign`             | Arrays of regex'es that allow to support custom attribute assign expressions (e.g. `'<div flex?="{{mode != cover}}"></div>'`) | `[ ]` |
 | `customAttrCollapse`           | Regex that specifies custom attribute to strip newlines from (e.g. `/ng-class/`) | |
@@ -76,6 +75,7 @@ How does HTMLMinifier compare to other solutions — [HTML Minifier from Will Pe
 | `removeTagWhitespace`          | Remove space between attributes whenever possible. **Note that this will result in invalid HTML!** | `false` |
 | `sortAttributes`               | [Sort attributes by frequency](#sorting-attributes--style-classes) | `false` |
 | `sortClassName`                | [Sort style classes by frequency](#sorting-attributes--style-classes) | `false` |
+| `trimCustomFragments`          | Trim white space around `ignoreCustomFragments`. | `false` |
 | `useShortDoctype`              | [Replaces the `doctype` with the short (HTML5) doctype](http://perfectionkills.com/experimenting-with-html-minifier/#use_short_doctype) | `false` |
 
 ### Sorting attributes / style classes

--- a/cli.js
+++ b/cli.js
@@ -101,7 +101,6 @@ var mainOptions = {
   collapseBooleanAttributes: 'Omit attribute values from boolean attributes',
   collapseInlineTagWhitespace: 'Collapse white space around inline tag',
   collapseWhitespace: 'Collapse white space that contributes to text nodes in a document tree.',
-  collapseCustomFragments: 'Collapse white space around ignoreCustomFragments.',
   conservativeCollapse: 'Always collapse to 1 space (never remove it entirely)',
   customAttrAssign: ['Arrays of regex\'es that allow to support custom attribute assign expressions (e.g. \'<div flex?="{{mode != cover}}"></div>\')', parseJSONRegExpArray],
   customAttrCollapse: ['Regex that specifies custom attribute to strip newlines from (e.g. /ng-class/)', parseRegExp],
@@ -133,6 +132,7 @@ var mainOptions = {
   removeTagWhitespace: 'Remove space between attributes whenever possible',
   sortAttributes: 'Sort attributes by frequency',
   sortClassName: 'Sort style classes by frequency',
+  trimCustomFragments: 'Trim white space around ignoreCustomFragments.',
   useShortDoctype: 'Replaces the doctype with the short (HTML5) doctype'
 };
 var mainOptionKeys = Object.keys(mainOptions);

--- a/cli.js
+++ b/cli.js
@@ -101,6 +101,7 @@ var mainOptions = {
   collapseBooleanAttributes: 'Omit attribute values from boolean attributes',
   collapseInlineTagWhitespace: 'Collapse white space around inline tag',
   collapseWhitespace: 'Collapse white space that contributes to text nodes in a document tree.',
+  collapseCustomFragments: 'Collapse white space around ignoreCustomFragments.',
   conservativeCollapse: 'Always collapse to 1 space (never remove it entirely)',
   customAttrAssign: ['Arrays of regex\'es that allow to support custom attribute assign expressions (e.g. \'<div flex?="{{mode != cover}}"></div>\')', parseJSONRegExpArray],
   customAttrCollapse: ['Regex that specifies custom attribute to strip newlines from (e.g. /ng-class/)', parseRegExp],

--- a/index.html
+++ b/index.html
@@ -58,6 +58,15 @@
             </span>
           </li>
           <li>
+            <input type="checkbox" id="collapseCustomFragments" checked>
+            <label for="collapseCustomFragments">
+              Collapse custom fragment white space
+            </label>
+            <span class="quiet short">
+              Collapse white space around <code>`ignoreCustomFragments</code>.
+            </span>
+          </li>
+          <li>
             <input type="checkbox" id="conservativeCollapse">
             <label for="conservativeCollapse">
               Conservative collapse

--- a/index.html
+++ b/index.html
@@ -58,15 +58,6 @@
             </span>
           </li>
           <li>
-            <input type="checkbox" id="collapseCustomFragments" checked>
-            <label for="collapseCustomFragments">
-              Collapse custom fragment white space
-            </label>
-            <span class="quiet short">
-              Collapse white space around <code>`ignoreCustomFragments</code>.
-            </span>
-          </li>
-          <li>
             <input type="checkbox" id="conservativeCollapse">
             <label for="conservativeCollapse">
               Conservative collapse
@@ -291,6 +282,15 @@
             </label>
             <span class="quiet short">
               Sort style classes by frequency
+            </span>
+          </li>
+          <li>
+            <input type="checkbox" id="trimCustomFragments" checked>
+            <label for="trimCustomFragments">
+              Trim white space around custom fragments
+            </label>
+            <span class="quiet short">
+              Trim white space around <code>ignoreCustomFragments</code>.
             </span>
           </li>
           <li>

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1260,7 +1260,7 @@ function minify(value, options, partialMarkup) {
         }
         return collapseWhitespace(chunk, {
           preserveLineBreaks: options.preserveLineBreaks,
-          conservativeCollapse: !options.collapseCustomFragments
+          conservativeCollapse: !options.trimCustomFragments
         }, /^\s/.test(chunk), /\s$/.test(chunk));
       }
       return chunk;

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1260,7 +1260,7 @@ function minify(value, options, partialMarkup) {
         }
         return collapseWhitespace(chunk, {
           preserveLineBreaks: options.preserveLineBreaks,
-          conservativeCollapse: true
+          conservativeCollapse: !options.collapseCustomFragments
         }, /^\s/.test(chunk), /\s$/.test(chunk));
       }
       return chunk;

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -1728,6 +1728,23 @@ QUnit.test('Ignore custom fragments', function(assert) {
       /\{%[^%]*?%\}/g
     ]
   }), input);
+  // trimCustomFragments withOUT collapseWhitespace, does
+  // not break the "{% foo %} {% bar %}" test
+  assert.equal(minify(input, {
+    ignoreCustomFragments: [
+      /\{%[^%]*?%\}/g
+    ],
+    trimCustomFragments: true
+  }), input);
+  // trimCustomFragments WITH collapseWhitespace, changes output
+  output = '<img class="{% foo %}{% bar %}">';
+  assert.equal(minify(input, {
+    ignoreCustomFragments: [
+      /\{%[^%]*?%\}/g
+    ],
+    collapseWhitespace: true,
+    trimCustomFragments: true
+  }), output);
 
   input = '<img class="titi.<%=tsItem_[0]%>">';
   assert.equal(minify(input), input);
@@ -1751,15 +1768,50 @@ QUnit.test('Ignore custom fragments', function(assert) {
     ]
   }), output);
 
-  input = '<?php echo "foo"; ?> <span>bar</span>';
+  // https://github.com/kangax/html-minifier/issues/722
+  input = '<? echo "foo"; ?> <span>bar</span>';
   assert.equal(minify(input), input);
   assert.equal(minify(input, {
     collapseWhitespace: true
   }), input);
-  output = '<?php echo "foo"; ?><span>bar</span>';
+  output = '<? echo "foo"; ?><span>bar</span>';
   assert.equal(minify(input, {
     collapseWhitespace: true,
-    collapseCustomFragments: true
+    trimCustomFragments: true
+  }), output);
+
+  input = ' <? echo "foo"; ?> bar';
+  assert.equal(minify(input), input);
+  output = '<? echo "foo"; ?> bar';
+  assert.equal(minify(input, {
+    collapseWhitespace: true
+  }), output);
+  output = '<? echo "foo"; ?>bar';
+  assert.equal(minify(input, {
+    collapseWhitespace: true,
+    trimCustomFragments: true
+  }), output);
+
+  input = '<span>foo</span> <? echo "bar"; ?> baz';
+  assert.equal(minify(input), input);
+  assert.equal(minify(input, {
+    collapseWhitespace: true
+  }), input);
+  output = '<span>foo</span><? echo "bar"; ?>baz';
+  assert.equal(minify(input, {
+    collapseWhitespace: true,
+    trimCustomFragments: true
+  }), output);
+
+  input = '<span>foo</span> <? echo "bar"; ?> <? echo "baz"; ?> <span>foo</span>';
+  assert.equal(minify(input), input);
+  assert.equal(minify(input, {
+    collapseWhitespace: true
+  }), input);
+  output = '<span>foo</span><? echo "bar"; ?><? echo "baz"; ?><span>foo</span>';
+  assert.equal(minify(input, {
+    collapseWhitespace: true,
+    trimCustomFragments: true
   }), output);
 });
 

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -1750,6 +1750,17 @@ QUnit.test('Ignore custom fragments', function(assert) {
       /\{\{.*?\}\}/g
     ]
   }), output);
+
+  input = '<?php echo "foo"; ?> <span>bar</span>';
+  assert.equal(minify(input), input);
+  assert.equal(minify(input, {
+    collapseWhitespace: true
+  }), input);
+  output = '<?php echo "foo"; ?><span>bar</span>';
+  assert.equal(minify(input, {
+    collapseWhitespace: true,
+    collapseCustomFragments: true
+  }), output);
 });
 
 QUnit.test('bootstrap\'s span > button > span', function(assert) {


### PR DESCRIPTION
…in order to collapse white space around `ignoreCustomFragments` (default: false).  This resolves issue #722.

Default behavior introduced from #436 is preserved.  Only setting `collapseCustomFragments` to `true` will collapse the white space.

_**Note:** I did not add the the compiled files in `dist/` in order to avoid merge conflict hell. Assumed you didn’t want that included in PRs._
