### PR TITLE
Remove change-case from dependencies

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -27,10 +27,11 @@
 
 'use strict';
 
-var changeCase = require('change-case');
+var camelCase = require('camel-case');
 var fs = require('fs');
 var info = require('./package.json');
 var minify = require('./' + info.main).minify;
+var paramCase = require('param-case');
 var path = require('path');
 var program = require('commander');
 
@@ -138,7 +139,7 @@ var mainOptions = {
 var mainOptionKeys = Object.keys(mainOptions);
 mainOptionKeys.forEach(function(key) {
   var option = mainOptions[key];
-  key = '--' + changeCase.paramCase(key);
+  key = '--' + paramCase(key);
   if (Array.isArray(option)) {
     var optional = option[1] === parseJSON;
     program.option(key + (optional ? ' [value]' : ' <value>'), option[0], option[1]);
@@ -197,7 +198,7 @@ program.arguments('[files...]').action(function(files) {
 function createOptions() {
   var options = {};
   mainOptionKeys.forEach(function(key) {
-    var param = program[changeCase.camelCase(key)];
+    var param = program[camelCase(key)];
     if (typeof param !== 'undefined') {
       options[key] = param;
     }

--- a/package.json
+++ b/package.json
@@ -54,11 +54,12 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "change-case": "3.0.x",
+    "camel-case": "3.0.x",
     "clean-css": "3.4.x",
     "commander": "2.9.x",
     "he": "1.1.x",
     "ncname": "1.0.x",
+    "param-case": "2.1.x",
     "relateurl": "0.2.x",
     "uglify-js": "2.7.x"
   },


### PR DESCRIPTION
Change-case lib is too distributed into packages that not needed and it has too much functionality twat we aren't using. Also we really need only one method in `cli.js` from it. So I suggest to remove this dependencies in favor of a simplified method.