### PR TITLE
Add ability to remove only empty `<script>` and `<style>` tags

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1113,6 +1113,22 @@ function minify(value, options, partialMarkup) {
           currentChars += '|';
         }
       }
+
+      if (options.removeEmptyScriptTags) {
+        if (isElementEmpty && tag === 'script') {
+          removeStartTag();
+        }
+        optionalStartTag = '';
+        optionalEndTag = '';
+      }
+
+      if (options.removeEmptyStyleTags) {
+        if (isElementEmpty && tag === 'style') {
+          removeStartTag();
+        }
+        optionalStartTag = '';
+        optionalEndTag = '';
+      }
     },
     chars: function(text, prevTag, nextTag) {
       prevTag = prevTag === '' ? 'comment' : prevTag;


### PR DESCRIPTION
I'd like the ability to remove empty `<script>` and `<style>` tags even when `removeEmptyElements` is disabled, these empty tags are much more safer to be removed than other empty elements.