### PR TITLE
handle &nbsp; better in collapseWhitespace

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -20,20 +20,10 @@ var trimWhitespace = String.prototype.trim ? function(str) {
   return str.replace(/^\s+/, '').replace(/\s+$/, '');
 };
 
-function compressWhitespace(spaces) {
-  return spaces === '\t' ? '\t' : spaces.replace(/(^|\xA0+)[^\xA0]+/g, '$1 ');
-}
-
 function collapseWhitespaceAll(str) {
-  return str && str.replace(/\s+/g, compressWhitespace);
-}
-
-function compressWhitespaceLeft(spaces) {
-  return spaces === '\t' ? '\t' : spaces.replace(/^[^\xA0]+/, '').replace(/(\xA0+)[^\xA0]+/g, '$1 ') || ' ';
-}
-
-function compressWhitespaceRight(spaces) {
-  return spaces === '\t' ? '\t' : spaces.replace(/[^\xA0]+(\xA0+)/g, ' $1').replace(/[^\xA0]+$/, '') || ' ';
+  return str && str.replace(/\s+/g, function(spaces) {
+    return spaces === '\t' ? '\t' : spaces.replace(/(^|\xA0+)[^\xA0]+/g, '$1 ');
+  });
 }
 
 function collapseWhitespace(str, options, trimLeft, trimRight, collapseAll) {
@@ -50,11 +40,23 @@ function collapseWhitespace(str, options, trimLeft, trimRight, collapseAll) {
   }
 
   if (trimLeft) {
-    str = str.replace(/^\s+/, !lineBreakBefore && options.conservativeCollapse ? compressWhitespaceLeft : '');
+    str = str.replace(/^\s+/, function(spaces) {
+      var conservative = !lineBreakBefore && options.conservativeCollapse;
+      if (conservative && spaces === '\t') {
+        return '\t';
+      }
+      return spaces.replace(/^[^\xA0]+/, '').replace(/(\xA0+)[^\xA0]+/g, '$1 ') || (conservative ? ' ' : '');
+    });
   }
 
   if (trimRight) {
-    str = str.replace(/\s+$/, !lineBreakAfter && options.conservativeCollapse ? compressWhitespaceRight : '');
+    str = str.replace(/\s+$/, function(spaces) {
+      var conservative = !lineBreakAfter && options.conservativeCollapse;
+      if (conservative && spaces === '\t') {
+        return '\t';
+      }
+      return spaces.replace(/[^\xA0]+(\xA0+)/g, ' $1').replace(/[^\xA0]+$/, '') || (conservative ? ' ' : '');
+    });
   }
 
   if (collapseAll) {

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -2320,6 +2320,7 @@ QUnit.test('conservative collapse', function(assert) {
   }), output);
 
   input = '<p>\u00A0</p>';
+  assert.equal(minify(input, { collapseWhitespace: true }), input);
   assert.equal(minify(input, {
     collapseWhitespace: true,
     conservativeCollapse: true
@@ -2327,6 +2328,7 @@ QUnit.test('conservative collapse', function(assert) {
 
   input = '<p> \u00A0</p>';
   output = '<p>\u00A0</p>';
+  assert.equal(minify(input, { collapseWhitespace: true }), output);
   assert.equal(minify(input, {
     collapseWhitespace: true,
     conservativeCollapse: true
@@ -2334,6 +2336,7 @@ QUnit.test('conservative collapse', function(assert) {
 
   input = '<p>\u00A0 </p>';
   output = '<p>\u00A0</p>';
+  assert.equal(minify(input, { collapseWhitespace: true }), output);
   assert.equal(minify(input, {
     collapseWhitespace: true,
     conservativeCollapse: true
@@ -2341,6 +2344,7 @@ QUnit.test('conservative collapse', function(assert) {
 
   input = '<p> \u00A0 </p>';
   output = '<p>\u00A0</p>';
+  assert.equal(minify(input, { collapseWhitespace: true }), output);
   assert.equal(minify(input, {
     collapseWhitespace: true,
     conservativeCollapse: true
@@ -2348,6 +2352,31 @@ QUnit.test('conservative collapse', function(assert) {
 
   input = '<p>  \u00A0\u00A0  \u00A0  </p>';
   output = '<p>\u00A0\u00A0 \u00A0</p>';
+  assert.equal(minify(input, { collapseWhitespace: true }), output);
+  assert.equal(minify(input, {
+    collapseWhitespace: true,
+    conservativeCollapse: true
+  }), output);
+
+  input = '<p>foo  \u00A0\u00A0  \u00A0  </p>';
+  output = '<p>foo \u00A0\u00A0 \u00A0</p>';
+  assert.equal(minify(input, { collapseWhitespace: true }), output);
+  assert.equal(minify(input, {
+    collapseWhitespace: true,
+    conservativeCollapse: true
+  }), output);
+
+  input = '<p>  \u00A0\u00A0  \u00A0  bar</p>';
+  output = '<p>\u00A0\u00A0 \u00A0 bar</p>';
+  assert.equal(minify(input, { collapseWhitespace: true }), output);
+  assert.equal(minify(input, {
+    collapseWhitespace: true,
+    conservativeCollapse: true
+  }), output);
+
+  input = '<p>foo  \u00A0\u00A0  \u00A0  bar</p>';
+  output = '<p>foo \u00A0\u00A0 \u00A0 bar</p>';
+  assert.equal(minify(input, { collapseWhitespace: true }), output);
   assert.equal(minify(input, {
     collapseWhitespace: true,
     conservativeCollapse: true
@@ -2355,6 +2384,7 @@ QUnit.test('conservative collapse', function(assert) {
 
   input = '<p> \u00A0foo\u00A0\t</p>';
   output = '<p>\u00A0foo\u00A0</p>';
+  assert.equal(minify(input, { collapseWhitespace: true }), output);
   assert.equal(minify(input, {
     collapseWhitespace: true,
     conservativeCollapse: true
@@ -2363,6 +2393,7 @@ QUnit.test('conservative collapse', function(assert) {
 
   input = '<p> \u00A0\nfoo\u00A0\t</p>';
   output = '<p>\u00A0 foo\u00A0</p>';
+  assert.equal(minify(input, { collapseWhitespace: true }), output);
   assert.equal(minify(input, {
     collapseWhitespace: true,
     conservativeCollapse: true
@@ -2371,6 +2402,7 @@ QUnit.test('conservative collapse', function(assert) {
 
   input = '<p> \u00A0foo \u00A0\t</p>';
   output = '<p>\u00A0foo \u00A0</p>';
+  assert.equal(minify(input, { collapseWhitespace: true }), output);
   assert.equal(minify(input, {
     collapseWhitespace: true,
     conservativeCollapse: true
@@ -2378,6 +2410,7 @@ QUnit.test('conservative collapse', function(assert) {
 
   input = '<p> \u00A0\nfoo \u00A0\t</p>';
   output = '<p>\u00A0 foo \u00A0</p>';
+  assert.equal(minify(input, { collapseWhitespace: true }), output);
   assert.equal(minify(input, {
     collapseWhitespace: true,
     conservativeCollapse: true


### PR DESCRIPTION
... so that people don't need to rely on `conservativeCollapse` for such use cases.