### PR TITLE
fix `sortClassName` on custom fragments

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -760,7 +760,7 @@ function createSortFns(value, options, uidIgnore, uidAttr) {
         for (var i = 0, len = attrs.length; i < len; i++) {
           var attr = attrs[i];
           if (classChain && (options.caseSensitive ? attr.name : attr.name.toLowerCase()) === 'class') {
-            classChain.add(trimWhitespace(attr.value).split(/\s+/).filter(shouldSkipUIDs));
+            classChain.add(trimWhitespace(attr.value).split(/[ \t\n\f\r]+/).filter(shouldSkipUIDs));
           }
           else if (options.processScripts && attr.name.toLowerCase() === 'type') {
             currentTag = tag;
@@ -808,7 +808,7 @@ function createSortFns(value, options, uidIgnore, uidAttr) {
   if (classChain) {
     var sorter = classChain.createSorter();
     options.sortClassName = function(value) {
-      return sorter.sort(value.split(/\s+/)).join(' ');
+      return sorter.sort(value.split(/[ \n\f\r]+/)).join(' ');
     };
   }
 }

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -3061,11 +3061,10 @@ QUnit.test('sort style classes', function(assert) {
     ignoreCustomFragments: [/<#[\s\S]*?#>/],
     sortClassName: false
   }), input);
-  output = '<div class="foo_bar nav_sv_fo_v_column <#=(j === 0) ? \'nav_sv_fo_v_first\' : \'\' #> "></div>';
   assert.equal(minify(input, {
     ignoreCustomFragments: [/<#[\s\S]*?#>/],
     sortClassName: true
-  }), output);
+  }), input);
 
   input = '<a class="0 1 2 3 4 5 6 7 8 9 a b c d e f g h i j k l m n o p q r s t u v w x y z"></a>';
   assert.equal(minify(input, { sortClassName: false }), input);
@@ -3075,6 +3074,14 @@ QUnit.test('sort style classes', function(assert) {
   assert.equal(minify(input, { sortClassName: false }), input);
   output = '<a class="add createSorter keys sort"></a>';
   assert.equal(minify(input, { sortClassName: true }), output);
+
+  input = '<span class="sprite sprite-{{sprite}}"></span>\n<span class="{{sprite}}"></span>';
+  output = '<span class="sprite sprite-{{sprite}}"></span> <span class="{{sprite}}"></span>';
+  assert.equal(minify(input, {
+    collapseWhitespace: true,
+    ignoreCustomFragments: [/{{.*}}/],
+    sortClassName: true
+  }), output);
 });
 
 QUnit.test('decode entity characters', function(assert) {

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -3075,11 +3075,44 @@ QUnit.test('sort style classes', function(assert) {
   output = '<a class="add createSorter keys sort"></a>';
   assert.equal(minify(input, { sortClassName: true }), output);
 
-  input = '<span class="sprite sprite-{{sprite}}"></span>\n<span class="{{sprite}}"></span>';
-  output = '<span class="sprite sprite-{{sprite}}"></span> <span class="{{sprite}}"></span>';
+  input = '<span class="sprite sprite-{{sprite}}"></span>';
   assert.equal(minify(input, {
     collapseWhitespace: true,
-    ignoreCustomFragments: [/{{.*}}/],
+    ignoreCustomFragments: [/{{.*?}}/],
+    removeAttributeQuotes: true,
+    sortClassName: true
+  }), input);
+
+  input = '<span class="{{sprite}}-sprite sprite"></span>';
+  assert.equal(minify(input, {
+    collapseWhitespace: true,
+    ignoreCustomFragments: [/{{.*?}}/],
+    removeAttributeQuotes: true,
+    sortClassName: true
+  }), input);
+
+  input = '<span class="sprite-{{sprite}}-sprite"></span>';
+  assert.equal(minify(input, {
+    collapseWhitespace: true,
+    ignoreCustomFragments: [/{{.*?}}/],
+    removeAttributeQuotes: true,
+    sortClassName: true
+  }), input);
+
+  input = '<span class="{{sprite}}"></span>';
+  assert.equal(minify(input, {
+    collapseWhitespace: true,
+    ignoreCustomFragments: [/{{.*?}}/],
+    removeAttributeQuotes: true,
+    sortClassName: true
+  }), input);
+
+  input = '<span class={{sprite}}></span>';
+  output = '<span class="{{sprite}}"></span>';
+  assert.equal(minify(input, {
+    collapseWhitespace: true,
+    ignoreCustomFragments: [/{{.*?}}/],
+    removeAttributeQuotes: true,
     sortClassName: true
   }), output);
 });


### PR DESCRIPTION
Prefer sub-optimal sort over extraneous whitespaces.

fixes #805