### PR TITLE
grunt qunit: Don't break in JSON.parse when debug output is generated while running the test suite

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -141,7 +141,15 @@ module.exports = function(grunt) {
           errors.push(-1);
         }
         else {
-          errors.push(report(testType, JSON.parse(result.stdout)));
+          var output = result.stdout;
+          var index = output.lastIndexOf('\n');
+          if (index !== -1) {
+            // There's something before the report JSON
+            // Log it to the console -- it's probably some debug output:
+            console.log(output.slice(0, index));
+            output = output.slice(index);
+          }
+          errors.push(report(testType, JSON.parse(output)));
         }
         if (errors.length === 2) {
           done(!errors[0] && !errors[1]);


### PR DESCRIPTION
I was trying to understand the code flow by adding a few console.log statements and running the test suite, but that made the qunit grunt task die because it assumes that it can `JSON.parse` the entire stdout output of running the tests.

This patch assumes that anything before the last newline character is test output, which should be logged.