### PR TITLE
Add the ability for options.can{Trim,Collapse}Whitespace to veto the default implementation when that returns true.

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -626,13 +626,11 @@ function processOptions(options) {
     options.log = identity;
   }
 
-  var defaultTesters = ['canCollapseWhitespace', 'canTrimWhitespace'];
-  for (var i = 0, len = defaultTesters.length; i < len; i++) {
-    if (!options[defaultTesters[i]]) {
-      options[defaultTesters[i]] = function() {
-        return false;
-      };
-    }
+  if (!options.canCollapseWhitespace) {
+    options.canCollapseWhitespace = canCollapseWhitespace;
+  }
+  if (!options.canTrimWhitespace) {
+    options.canTrimWhitespace = canTrimWhitespace;
   }
 
   if (!('ignoreCustomComments' in options)) {
@@ -894,11 +892,11 @@ function minify(value, options, partialMarkup) {
   }
 
   function _canCollapseWhitespace(tag, attrs) {
-    return canCollapseWhitespace(tag) || options.canCollapseWhitespace(tag, attrs);
+    return options.canCollapseWhitespace(tag, attrs, canCollapseWhitespace);
   }
 
   function _canTrimWhitespace(tag, attrs) {
-    return canTrimWhitespace(tag) || options.canTrimWhitespace(tag, attrs);
+    return options.canTrimWhitespace(tag, attrs, canTrimWhitespace);
   }
 
   function removeStartTag() {


### PR DESCRIPTION
Also, provide the default implementation as the 3rd parameter to the custom hook so the user doesn't have to reimplement it.