### PR TITLE
Fix stackNoTrimWhitespace and stackNoCollapseWhitespace housekeeping

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -998,10 +998,10 @@ function minify(value, options, partialMarkup) {
         if (!stackNoTrimWhitespace.length) {
           squashTrailingWhitespace(tag);
         }
-        if (!_canTrimWhitespace(tag, attrs)) {
+        if (!_canTrimWhitespace(tag, attrs) || stackNoTrimWhitespace.length) {
           stackNoTrimWhitespace.push(tag);
         }
-        if (!_canCollapseWhitespace(tag, attrs)) {
+        if (!_canCollapseWhitespace(tag, attrs) || stackNoCollapseWhitespace.length) {
           stackNoCollapseWhitespace.push(tag);
         }
       }


### PR DESCRIPTION
Previously the first encountered end tag matching the top item would clear it from the stack, regardless of whether the two were actually a start + end pair.

Consider the document:

```html
<div id=foo><div></div>foo  bar</div>
```

If `options.canTrimWhitespace` returned false for `<div id=foo>`, that would push `'div'` onto `stackNoTrimWhitespace`, but it would be cleared again when the first `</div>` is encountered, and thus `foo  bar` would have its whitespace squeezed so it comes out as `foo bar`. Since it works fine without the `<div></div>`.

My suggested fix is to add every encountered tag to `stackNoTrimWhitespace` (and `stackNoCollapseWhitespace`) when the stack isn't already empty. That makes sure that the end tags always pair up correctly with the stack items.