### PR TITLE
Preserve en/em/non-breaking/hair space etc. while minifying

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -17,11 +17,11 @@ var trimWhitespace = String.prototype.trim ? function(str) {
   if (typeof str !== 'string') {
     return str;
   }
-  return str.replace(/^\s+/, '').replace(/\s+$/, '');
+  return str.replace(/^[ \n\r\t]+/, '').replace(/[ \n\r\t]+$/, '');
 };
 
 function collapseWhitespaceAll(str) {
-  return str && str.replace(/\s+/g, function(spaces) {
+  return str && str.replace(/[ \n\r\t]+/g, function(spaces) {
     return spaces === '\t' ? '\t' : spaces.replace(/(^|\xA0+)[^\xA0]+/g, '$1 ');
   });
 }
@@ -30,17 +30,18 @@ function collapseWhitespace(str, options, trimLeft, trimRight, collapseAll) {
   var lineBreakBefore = '', lineBreakAfter = '';
 
   if (options.preserveLineBreaks) {
-    str = str.replace(/^\s*?[\n\r]\s*/, function() {
+    str = str.replace(/^[ \n\r\t]*?[\n\r][ \n\r\t]*/, function() {
       lineBreakBefore = '\n';
       return '';
-    }).replace(/\s*?[\n\r]\s*$/, function() {
+    }).replace(/[ \n\r\t]*?[\n\r][ \n\r\t]*$/, function() {
       lineBreakAfter = '\n';
       return '';
     });
   }
 
   if (trimLeft) {
-    str = str.replace(/^\s+/, function(spaces) {
+    // Non-breaking space is specifically handled inside the replacer function here:
+    str = str.replace(/^[ \n\r\t\xA0]+/, function(spaces) {
       var conservative = !lineBreakBefore && options.conservativeCollapse;
       if (conservative && spaces === '\t') {
         return '\t';
@@ -50,7 +51,8 @@ function collapseWhitespace(str, options, trimLeft, trimRight, collapseAll) {
   }
 
   if (trimRight) {
-    str = str.replace(/\s+$/, function(spaces) {
+    // Non-breaking space is specifically handled inside the replacer function here:
+    str = str.replace(/[ \n\r\t\xA0]+$/, function(spaces) {
       var conservative = !lineBreakAfter && options.conservativeCollapse;
       if (conservative && spaces === '\t') {
         return '\t';
@@ -1122,7 +1124,7 @@ function minify(value, options, partialMarkup) {
               }
               if (buffer.length > 1 && (!prevComment || !options.conservativeCollapse && / $/.test(currentChars))) {
                 var charsIndex = buffer.length - 2;
-                buffer[charsIndex] = buffer[charsIndex].replace(/\s+$/, function(trailingSpaces) {
+                buffer[charsIndex] = buffer[charsIndex].replace(/[ \n\r\t]+$/, function(trailingSpaces) {
                   text = trailingSpaces + text;
                   return '';
                 });
@@ -1140,7 +1142,7 @@ function minify(value, options, partialMarkup) {
               }
             }
             else if (inlineTextTags(prevTag.charAt(0) === '/' ? prevTag.slice(1) : prevTag)) {
-              text = collapseWhitespace(text, options, /(?:^|\s)$/.test(currentChars));
+              text = collapseWhitespace(text, options, /(?:^|[ \n\r\t])$/.test(currentChars));
             }
           }
           if (prevTag || nextTag) {
@@ -1149,7 +1151,7 @@ function minify(value, options, partialMarkup) {
           else {
             text = collapseWhitespace(text, options, true, true);
           }
-          if (!text && /\s$/.test(currentChars) && prevTag && prevTag.charAt(0) === '/') {
+          if (!text && /[ \n\r\t]$/.test(currentChars) && prevTag && prevTag.charAt(0) === '/') {
             trimTrailingWhitespace(buffer.length - 1, nextTag);
           }
         }
@@ -1169,18 +1171,18 @@ function minify(value, options, partialMarkup) {
       if (options.removeOptionalTags && text) {
         // <html> may be omitted if first thing inside is not comment
         // <body> may be omitted if first thing inside is not space, comment, <meta>, <link>, <script>, <style> or <template>
-        if (optionalStartTag === 'html' || optionalStartTag === 'body' && !/^\s/.test(text)) {
+        if (optionalStartTag === 'html' || optionalStartTag === 'body' && !/^[ \n\r\t]/.test(text)) {
           removeStartTag();
         }
         optionalStartTag = '';
         // </html> or </body> may be omitted if not followed by comment
         // </head>, </colgroup> or </caption> may be omitted if not followed by space or comment
-        if (compactTags(optionalEndTag) || looseTags(optionalEndTag) && !/^\s/.test(text)) {
+        if (compactTags(optionalEndTag) || looseTags(optionalEndTag) && !/^[ \n\r\t]/.test(text)) {
           removeEndTag();
         }
         optionalEndTag = '';
       }
-      charsPrevTag = /^\s*$/.test(text) ? prevTag : 'comment';
+      charsPrevTag = /^[ \n\r\t]*$/.test(text) ? prevTag : 'comment';
       if (options.decodeEntities && text && !specialContentTags(currentTag)) {
         // semi-colon can be omitted
         // https://mathiasbynens.be/notes/ambiguous-ampersands
@@ -1253,7 +1255,7 @@ function minify(value, options, partialMarkup) {
         return collapseWhitespace(chunk, {
           preserveLineBreaks: options.preserveLineBreaks,
           conservativeCollapse: !options.trimCustomFragments
-        }, /^\s/.test(chunk), /\s$/.test(chunk));
+        }, /^[ \n\r\t]/.test(chunk), /[ \n\r\t]$/.test(chunk));
       }
       return chunk;
     });

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1120,7 +1120,7 @@ function minify(value, options, partialMarkup) {
               }
               if (buffer.length > 1 && (!prevComment || !options.conservativeCollapse && / $/.test(currentChars))) {
                 var charsIndex = buffer.length - 2;
-                buffer[charsIndex] = buffer[charsIndex].replace(/[ \n\r\t\f]+$/, function(trailingSpaces) {
+                buffer[charsIndex] = buffer[charsIndex].replace(/\s+$/, function(trailingSpaces) {
                   text = trailingSpaces + text;
                   return '';
                 });
@@ -1138,7 +1138,7 @@ function minify(value, options, partialMarkup) {
               }
             }
             else if (inlineTextTags(prevTag.charAt(0) === '/' ? prevTag.slice(1) : prevTag)) {
-              text = collapseWhitespace(text, options, /(?:^|[ \n\r\t\f])$/.test(currentChars));
+              text = collapseWhitespace(text, options, /(?:^|\s)$/.test(currentChars));
             }
           }
           if (prevTag || nextTag) {
@@ -1147,7 +1147,7 @@ function minify(value, options, partialMarkup) {
           else {
             text = collapseWhitespace(text, options, true, true);
           }
-          if (!text && /[ \n\r\t\f]$/.test(currentChars) && prevTag && prevTag.charAt(0) === '/') {
+          if (!text && /\s$/.test(currentChars) && prevTag && prevTag.charAt(0) === '/') {
             trimTrailingWhitespace(buffer.length - 1, nextTag);
           }
         }
@@ -1167,18 +1167,18 @@ function minify(value, options, partialMarkup) {
       if (options.removeOptionalTags && text) {
         // <html> may be omitted if first thing inside is not comment
         // <body> may be omitted if first thing inside is not space, comment, <meta>, <link>, <script>, <style> or <template>
-        if (optionalStartTag === 'html' || optionalStartTag === 'body' && !/^[ \n\r\t\f]/.test(text)) {
+        if (optionalStartTag === 'html' || optionalStartTag === 'body' && !/^\s/.test(text)) {
           removeStartTag();
         }
         optionalStartTag = '';
         // </html> or </body> may be omitted if not followed by comment
         // </head>, </colgroup> or </caption> may be omitted if not followed by space or comment
-        if (compactTags(optionalEndTag) || looseTags(optionalEndTag) && !/^[ \n\r\t\f]/.test(text)) {
+        if (compactTags(optionalEndTag) || looseTags(optionalEndTag) && !/^\s/.test(text)) {
           removeEndTag();
         }
         optionalEndTag = '';
       }
-      charsPrevTag = /^[ \n\r\t\f]*$/.test(text) ? prevTag : 'comment';
+      charsPrevTag = /^\s*$/.test(text) ? prevTag : 'comment';
       if (options.decodeEntities && text && !specialContentTags(currentTag)) {
         // semi-colon can be omitted
         // https://mathiasbynens.be/notes/ambiguous-ampersands

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -17,11 +17,11 @@ var trimWhitespace = String.prototype.trim ? function(str) {
   if (typeof str !== 'string') {
     return str;
   }
-  return str.replace(/^[ \n\r\t]+/, '').replace(/[ \n\r\t]+$/, '');
+  return str.replace(/^[ \n\r\t\f]+/, '').replace(/[ \n\r\t\f]+$/, '');
 };
 
 function collapseWhitespaceAll(str) {
-  return str && str.replace(/[ \n\r\t]+/g, function(spaces) {
+  return str && str.replace(/[ \n\r\t\f]+/g, function(spaces) {
     return spaces === '\t' ? '\t' : spaces.replace(/(^|\xA0+)[^\xA0]+/g, '$1 ');
   });
 }
@@ -30,10 +30,10 @@ function collapseWhitespace(str, options, trimLeft, trimRight, collapseAll) {
   var lineBreakBefore = '', lineBreakAfter = '';
 
   if (options.preserveLineBreaks) {
-    str = str.replace(/^[ \n\r\t]*?[\n\r][ \n\r\t]*/, function() {
+    str = str.replace(/^[ \n\r\t\f]*?[\n\r][ \n\r\t\f]*/, function() {
       lineBreakBefore = '\n';
       return '';
-    }).replace(/[ \n\r\t]*?[\n\r][ \n\r\t]*$/, function() {
+    }).replace(/[ \n\r\t\f]*?[\n\r][ \n\r\t\f]*$/, function() {
       lineBreakAfter = '\n';
       return '';
     });
@@ -41,7 +41,7 @@ function collapseWhitespace(str, options, trimLeft, trimRight, collapseAll) {
 
   if (trimLeft) {
     // Non-breaking space is specifically handled inside the replacer function here:
-    str = str.replace(/^[ \n\r\t\xA0]+/, function(spaces) {
+    str = str.replace(/^[ \n\r\t\f\xA0]+/, function(spaces) {
       var conservative = !lineBreakBefore && options.conservativeCollapse;
       if (conservative && spaces === '\t') {
         return '\t';
@@ -52,7 +52,7 @@ function collapseWhitespace(str, options, trimLeft, trimRight, collapseAll) {
 
   if (trimRight) {
     // Non-breaking space is specifically handled inside the replacer function here:
-    str = str.replace(/[ \n\r\t\xA0]+$/, function(spaces) {
+    str = str.replace(/[ \n\r\t\f\xA0]+$/, function(spaces) {
       var conservative = !lineBreakAfter && options.conservativeCollapse;
       if (conservative && spaces === '\t') {
         return '\t';
@@ -1124,7 +1124,7 @@ function minify(value, options, partialMarkup) {
               }
               if (buffer.length > 1 && (!prevComment || !options.conservativeCollapse && / $/.test(currentChars))) {
                 var charsIndex = buffer.length - 2;
-                buffer[charsIndex] = buffer[charsIndex].replace(/[ \n\r\t]+$/, function(trailingSpaces) {
+                buffer[charsIndex] = buffer[charsIndex].replace(/[ \n\r\t\f]+$/, function(trailingSpaces) {
                   text = trailingSpaces + text;
                   return '';
                 });
@@ -1142,7 +1142,7 @@ function minify(value, options, partialMarkup) {
               }
             }
             else if (inlineTextTags(prevTag.charAt(0) === '/' ? prevTag.slice(1) : prevTag)) {
-              text = collapseWhitespace(text, options, /(?:^|[ \n\r\t])$/.test(currentChars));
+              text = collapseWhitespace(text, options, /(?:^|[ \n\r\t\f])$/.test(currentChars));
             }
           }
           if (prevTag || nextTag) {
@@ -1151,7 +1151,7 @@ function minify(value, options, partialMarkup) {
           else {
             text = collapseWhitespace(text, options, true, true);
           }
-          if (!text && /[ \n\r\t]$/.test(currentChars) && prevTag && prevTag.charAt(0) === '/') {
+          if (!text && /[ \n\r\t\f]$/.test(currentChars) && prevTag && prevTag.charAt(0) === '/') {
             trimTrailingWhitespace(buffer.length - 1, nextTag);
           }
         }
@@ -1171,18 +1171,18 @@ function minify(value, options, partialMarkup) {
       if (options.removeOptionalTags && text) {
         // <html> may be omitted if first thing inside is not comment
         // <body> may be omitted if first thing inside is not space, comment, <meta>, <link>, <script>, <style> or <template>
-        if (optionalStartTag === 'html' || optionalStartTag === 'body' && !/^[ \n\r\t]/.test(text)) {
+        if (optionalStartTag === 'html' || optionalStartTag === 'body' && !/^[ \n\r\t\f]/.test(text)) {
           removeStartTag();
         }
         optionalStartTag = '';
         // </html> or </body> may be omitted if not followed by comment
         // </head>, </colgroup> or </caption> may be omitted if not followed by space or comment
-        if (compactTags(optionalEndTag) || looseTags(optionalEndTag) && !/^[ \n\r\t]/.test(text)) {
+        if (compactTags(optionalEndTag) || looseTags(optionalEndTag) && !/^[ \n\r\t\f]/.test(text)) {
           removeEndTag();
         }
         optionalEndTag = '';
       }
-      charsPrevTag = /^[ \n\r\t]*$/.test(text) ? prevTag : 'comment';
+      charsPrevTag = /^[ \n\r\t\f]*$/.test(text) ? prevTag : 'comment';
       if (options.decodeEntities && text && !specialContentTags(currentTag)) {
         // semi-colon can be omitted
         // https://mathiasbynens.be/notes/ambiguous-ampersands
@@ -1255,7 +1255,7 @@ function minify(value, options, partialMarkup) {
         return collapseWhitespace(chunk, {
           preserveLineBreaks: options.preserveLineBreaks,
           conservativeCollapse: !options.trimCustomFragments
-        }, /^[ \n\r\t]/.test(chunk), /[ \n\r\t]$/.test(chunk));
+        }, /^[ \n\r\t\f]/.test(chunk), /[ \n\r\t\f]$/.test(chunk));
       }
       return chunk;
     });

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -21,7 +21,8 @@ var trimWhitespace = String.prototype.trim ? function(str) {
 };
 
 function collapseWhitespaceAll(str) {
-  return str && str.replace(/[ \n\r\t\f]+/g, function(spaces) {
+  // Non-breaking space is specifically handled inside the replacer function here:
+  return str && str.replace(/[ \n\r\t\f\xA0]+/g, function(spaces) {
     return spaces === '\t' ? '\t' : spaces.replace(/(^|\xA0+)[^\xA0]+/g, '$1 ');
   });
 }

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -8,17 +8,12 @@ var TokenChain = require('./tokenchain');
 var UglifyJS = require('uglify-js');
 var utils = require('./utils');
 
-var trimWhitespace = String.prototype.trim ? function(str) {
-  if (typeof str !== 'string') {
-    return str;
-  }
-  return str.trim();
-} : function(str) {
+function trimWhitespace(str) {
   if (typeof str !== 'string') {
     return str;
   }
   return str.replace(/^[ \n\r\t\f]+/, '').replace(/[ \n\r\t\f]+$/, '');
-};
+}
 
 function collapseWhitespaceAll(str) {
   // Non-breaking space is specifically handled inside the replacer function here:

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -370,6 +370,10 @@ QUnit.test('types of whitespace that should always be preserved', function(asser
 
   // Non-breaking space passed as HTML entity, in decodeEntities:true mode:
   assert.equal(minify(inputWithEntities, { collapseWhitespace: true, decodeEntities: true }), input);
+
+  // Do not remove hair space when preserving line breaks between tags:
+  input = '<p></p>\u200a\n<p></p>\n';
+  assert.equal(minify(input, { collapseWhitespace: true, preserveLineBreaks: true }), input);
 });
 
 QUnit.test('doctype normalization', function(assert) {

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -347,6 +347,31 @@ QUnit.test('space normalization around text', function(assert) {
   assert.equal(minify(input, { collapseWhitespace: true }), output);
 });
 
+QUnit.test('types of whitespace that should always be preserved', function(assert) {
+  // Hair space:
+  var input = '<div>\u200afo\u200ao\u200a</div>';
+  assert.equal(minify(input, { collapseWhitespace: true }), input);
+
+  // Hair space passed as HTML entity:
+  var inputWithEntities = '<div>&#8202;fo&#8202;o&#8202;</div>';
+  assert.equal(minify(inputWithEntities, { collapseWhitespace: true }), inputWithEntities);
+
+  // Hair space passed as HTML entity, in decodeEntities:true mode:
+  assert.equal(minify(inputWithEntities, { collapseWhitespace: true, decodeEntities: true }), input);
+
+
+  // Non-breaking space:
+  input = '<div>\xa0fo\xa0o\xa0</div>';
+  assert.equal(minify(input, { collapseWhitespace: true }), input);
+
+  // Non-breaking space passed as HTML entity:
+  inputWithEntities = '<div>&nbsp;fo&nbsp;o&nbsp;</div>';
+  assert.equal(minify(inputWithEntities, { collapseWhitespace: true }), inputWithEntities);
+
+  // Non-breaking space passed as HTML entity, in decodeEntities:true mode:
+  assert.equal(minify(inputWithEntities, { collapseWhitespace: true, decodeEntities: true }), input);
+});
+
 QUnit.test('doctype normalization', function(assert) {
   var input;
 

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -374,6 +374,15 @@ QUnit.test('types of whitespace that should always be preserved', function(asser
   // Do not remove hair space when preserving line breaks between tags:
   input = '<p></p>\u200a\n<p></p>\n';
   assert.equal(minify(input, { collapseWhitespace: true, preserveLineBreaks: true }), input);
+
+  // Preserve hair space in attributes:
+  input = '<p class="foo\u200abar"></p>';
+  assert.equal(minify(input, { collapseWhitespace: true }), input);
+
+  // Preserve hair space in class names when deduplicating and reordering:
+  input = '<a class="0 1\u200a3 2 3"></a>';
+  assert.equal(minify(input, { sortClassName: false }), input);
+  assert.equal(minify(input, { sortClassName: true }), input);
 });
 
 QUnit.test('doctype normalization', function(assert) {


### PR DESCRIPTION
There are some "precious" space characters matched by /\s/ that should never be collapsed or trimmed away.

See https://github.com/assetgraph/assetgraph/pull/778