### PR TITLE
Remove \t in customFragments tokens

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -880,6 +880,8 @@ function minify(value, options, partialMarkup) {
       }
       var token = uidAttr + ignoredCustomMarkupChunks.length;
       ignoredCustomMarkupChunks.push(/^(\s*)[\s\S]*?(\s*)$/.exec(match));
+      // return '\t' + token + '\t';
+      // remove \t in token
       return token;
     });
   }

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -880,7 +880,7 @@ function minify(value, options, partialMarkup) {
       }
       var token = uidAttr + ignoredCustomMarkupChunks.length;
       ignoredCustomMarkupChunks.push(/^(\s*)[\s\S]*?(\s*)$/.exec(match));
-      return '\t' + token + '\t';
+      return token;
     });
   }
 


### PR DESCRIPTION
I am using **html-loader** and I found an issue on that. [Issue](https://github.com/webpack-contrib/html-loader/issues/148)

While I researching about that I just saw your codes. You have replaced customFragments with equals tokens of that in **htmlminifier.js**. But you have added tabs(\t) before and after the tokens. I have just removed these tabs(\t). After removing my issue fixed. I don't know If my changes are worth. But you must consider in these cases. Thank you!