### PR TITLE
preserve whitespace around custom fragments within `<pre>`

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1153,6 +1153,11 @@ function minify(value, options, partialMarkup) {
             trimTrailingWhitespace(buffer.length - 1, nextTag);
           }
         }
+        else if (uidPattern) {
+          text = text.replace(uidPattern, function(match, prefix, index) {
+            return ignoredCustomMarkupChunks[+index][0];
+          });
+        }
         if (!stackNoCollapseWhitespace.length && nextTag !== 'html' && !(prevTag && nextTag)) {
           text = collapseWhitespace(text, options, false, false, true);
         }

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -1918,6 +1918,10 @@ QUnit.test('Ignore custom fragments', function(assert) {
   input = '<link href="<?php echo \'http://foo/\' ?>">';
   assert.equal(minify(input), input);
   assert.equal(minify(input, { removeAttributeQuotes: true }), input);
+
+  input = '<pre>\nfoo\n<? bar ?>\nbaz\n</pre>';
+  assert.equal(minify(input), input);
+  assert.equal(minify(input, { collapseWhitespace: true }), input);
 });
 
 QUnit.test('bootstrap\'s span > button > span', function(assert) {


### PR DESCRIPTION
fixes #836