### PR TITLE
Callback Support

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1176,7 +1176,7 @@ function minify(value, options, partialMarkup, cb) {
           tasksWaitingFor++;
           var minifyJSResult = options.minifyJS(text, null, onTaskFinished);
 
-          // If the result is defined then minifyJSResult completed synchronously.
+          // If the result is defined then minifyJS completed synchronously.
           // eslint-disable-next-line no-undefined
           if (minifyJSResult !== undefined) {
             onTaskFinished(minifyJSResult);

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -941,6 +941,7 @@ function minify(value, options, partialMarkup, cb) {
     trimTrailingWhitespace(charsIndex, nextTag);
   }
 
+  var str;
   new HTMLParser(value, {
     partialMarkup: partialMarkup,
     html5: options.html5,
@@ -1226,50 +1227,55 @@ function minify(value, options, partialMarkup, cb) {
     },
     customAttrAssign: options.customAttrAssign,
     customAttrSurround: options.customAttrSurround
+  }).onComplete(function() {
+    if (options.removeOptionalTags) {
+      // <html> may be omitted if first thing inside is not comment
+      // <head> or <body> may be omitted if empty
+      if (topLevelTags(optionalStartTag)) {
+        removeStartTag();
+      }
+      // except for </dt> or </thead>, end tags may be omitted if no more content in parent element
+      if (optionalEndTag && !trailingTags(optionalEndTag)) {
+        removeEndTag();
+      }
+    }
+    if (options.collapseWhitespace) {
+      squashTrailingWhitespace('br');
+    }
+
+    str = joinResultSegments(buffer, options);
+
+    if (uidPattern) {
+      str = str.replace(uidPattern, function(match, prefix, index, suffix) {
+        var chunk = ignoredCustomMarkupChunks[+index][0];
+        if (options.collapseWhitespace) {
+          if (prefix !== '\t') {
+            chunk = prefix + chunk;
+          }
+          if (suffix !== '\t') {
+            chunk += suffix;
+          }
+          return collapseWhitespace(chunk, {
+            preserveLineBreaks: options.preserveLineBreaks,
+            conservativeCollapse: !options.trimCustomFragments
+          }, /^[ \n\r\t\f]/.test(chunk), /[ \n\r\t\f]$/.test(chunk));
+        }
+        return chunk;
+      });
+    }
+    if (uidIgnore) {
+      str = str.replace(new RegExp('<!--' + uidIgnore + '([0-9]+)-->', 'g'), function(match, index) {
+        return ignoredMarkupChunks[+index];
+      });
+    }
+
+    options.log('minified in: ' + (Date.now() - t) + 'ms');
+
+    if (typeof cb === 'function') {
+      cb(str);
+    }
   });
 
-  if (options.removeOptionalTags) {
-    // <html> may be omitted if first thing inside is not comment
-    // <head> or <body> may be omitted if empty
-    if (topLevelTags(optionalStartTag)) {
-      removeStartTag();
-    }
-    // except for </dt> or </thead>, end tags may be omitted if no more content in parent element
-    if (optionalEndTag && !trailingTags(optionalEndTag)) {
-      removeEndTag();
-    }
-  }
-  if (options.collapseWhitespace) {
-    squashTrailingWhitespace('br');
-  }
-
-  var str = joinResultSegments(buffer, options);
-
-  if (uidPattern) {
-    str = str.replace(uidPattern, function(match, prefix, index, suffix) {
-      var chunk = ignoredCustomMarkupChunks[+index][0];
-      if (options.collapseWhitespace) {
-        if (prefix !== '\t') {
-          chunk = prefix + chunk;
-        }
-        if (suffix !== '\t') {
-          chunk += suffix;
-        }
-        return collapseWhitespace(chunk, {
-          preserveLineBreaks: options.preserveLineBreaks,
-          conservativeCollapse: !options.trimCustomFragments
-        }, /^[ \n\r\t\f]/.test(chunk), /[ \n\r\t\f]$/.test(chunk));
-      }
-      return chunk;
-    });
-  }
-  if (uidIgnore) {
-    str = str.replace(new RegExp('<!--' + uidIgnore + '([0-9]+)-->', 'g'), function(match, index) {
-      return ignoredMarkupChunks[+index];
-    });
-  }
-
-  options.log('minified in: ' + (Date.now() - t) + 'ms');
   return str;
 }
 

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -803,7 +803,7 @@ function createSortFns(value, options, uidIgnore, uidAttr) {
   }
 }
 
-function minify(value, options, partialMarkup) {
+function minify(value, options, partialMarkup, cb) {
   options = options || {};
   var optionsStack = [];
   processOptions(options);
@@ -1300,6 +1300,6 @@ function joinResultSegments(results, options) {
   return options.collapseWhitespace ? collapseWhitespace(str, options, true, true) : str;
 }
 
-exports.minify = function(value, options) {
-  return minify(value, options);
+exports.minify = function(value, options, cb) {
+  return minify(value, options, null, cb);
 };

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1177,8 +1177,7 @@ function minify(value, options, partialMarkup, cb) {
           var minifyJSResult = options.minifyJS(text, null, onTaskFinished);
 
           // If the result is defined then minifyJS completed synchronously.
-          // eslint-disable-next-line no-undefined
-          if (minifyJSResult !== undefined) {
+          if (typeof minifyJSResult !== 'undefined') {
             onTaskFinished(minifyJSResult);
           }
         }
@@ -1193,8 +1192,7 @@ function minify(value, options, partialMarkup, cb) {
           var minifyCSSResult = options.minifyCSS(text, onTaskFinished);
 
           // If the result is defined then minifyCSS completed synchronously.
-          // eslint-disable-next-line no-undefined
-          if (minifyCSSResult !== undefined) {
+          if (typeof minifyCSSResult !== 'undefined') {
             onTaskFinished(minifyCSSResult);
           }
         }

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -867,14 +867,14 @@ function minify(value, options, partialMarkup, cb) {
         uidPattern = new RegExp('(\\s*)' + uidAttr + '([0-9]+)(\\s*)', 'g');
         var minifyCSS = options.minifyCSS;
         if (minifyCSS) {
-          options.minifyCSS = function(text) {
-            return minifyCSS(escapeFragments(text));
+          options.minifyCSS = function(text, cb) {
+            return minifyCSS(escapeFragments(text), cb);
           };
         }
         var minifyJS = options.minifyJS;
         if (minifyJS) {
-          options.minifyJS = function(text, inline) {
-            return minifyJS(escapeFragments(text), inline);
+          options.minifyJS = function(text, inline, cb) {
+            return minifyJS(escapeFragments(text), inline, cb);
           };
         }
       }

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -398,6 +398,20 @@ function HTMLParser(html, handler) {
   }
 }
 
+/**
+ * Called when the HTMLParser has finished.
+ *
+ * @param {Function} cb - Callback function.
+ */
+HTMLParser.prototype.onComplete = function(cb) {
+  if (this.finished) {
+    cb();
+  }
+  else {
+    this.onCompleteCallback = cb;
+  }
+};
+
 exports.HTMLParser = HTMLParser;
 exports.HTMLtoXML = function(html) {
   var results = '';

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -225,7 +225,11 @@ function HTMLParser(html, handler) {
           text,
           prevTag,
           nextTag,
-          function() {
+          function(error) {
+            if (error) {
+              return handleError(error);
+            }
+
             prevTag = '';
             checkForParseError();
           }
@@ -252,7 +256,11 @@ function HTMLParser(html, handler) {
           charsText,
           null,
           null,
-          function() {
+          function(error) {
+            if (error) {
+              return handleError(error);
+            }
+
             html = html.substring(0, replaceDetails.index) + html.substring(replaceDetails.index + replaceDetails[0].length);
             parseEndTag('</' + stackedTag + '>', stackedTag);
             checkForParseError();
@@ -267,7 +275,7 @@ function HTMLParser(html, handler) {
 
     function checkForParseError() {
       if (html === last) {
-        throw new Error('Parse Error: ' + html);
+        return handleError(new Error('Parse Error: ' + html));
       }
 
       return parse();
@@ -283,6 +291,13 @@ function HTMLParser(html, handler) {
     $this.finished = true;
     if ($this.onCompleteCallback) {
       $this.onCompleteCallback();
+    }
+  }
+
+  function handleError(error) {
+    $this.error = error;
+    if ($this.onErrorCallback) {
+      $this.onErrorCallback(error);
     }
   }
 
@@ -449,6 +464,20 @@ HTMLParser.prototype.onComplete = function(cb) {
   }
   else {
     this.onCompleteCallback = cb;
+  }
+};
+
+/**
+ * Called when the HTMLParser encounters an error.
+ *
+ * @param {Function} cb - Callback function.
+ */
+HTMLParser.prototype.onError = function(cb) {
+  if (this.error) {
+    cb(this.error);
+  }
+  else {
+    this.onErrorCallback = cb;
   }
 };
 

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -126,6 +126,8 @@ function HTMLParser(html, handler) {
       return cb();
     }
 
+    var waitingForCallback = false;
+
     last = html;
     // Make sure we're not in a script or style element
     if (!lastTag || !special(lastTag)) {
@@ -239,14 +241,18 @@ function HTMLParser(html, handler) {
       });
 
       parseEndTag('</' + stackedTag + '>', stackedTag);
+
+    if (!waitingForCallback) {
+      return checkForParseError(cb);
     }
 
-    if (html === last) {
-      throw new Error('Parse Error: ' + html);
+    function checkForParseError(cb) {
+      if (html === last) {
+        throw new Error('Parse Error: ' + html);
+      }
+
+      return iterate(cb);
     }
-
-
-    return iterate(cb);
   })(function() {
     if (!handler.partialMarkup) {
       // Clean up any remaining tags

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -122,6 +122,8 @@ function HTMLParser(html, handler) {
   var attribute = attrForHandler(handler);
   var last, prevTag, nextTag;
 
+  parse();
+
   function parse() {
     if (!html) {
       return parseComplete();
@@ -271,8 +273,6 @@ function HTMLParser(html, handler) {
       return parse();
     }
   }
-
-  parse();
 
   function parseComplete() {
     if (!handler.partialMarkup) {

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -3397,3 +3397,43 @@ QUnit.test('canCollapseWhitespace and canTrimWhitespace hooks', function(assert)
     canCollapseWhitespace: canCollapseAndTrimWhitespace
   }), output);
 });
+
+QUnit.test('style minification with callback', function(assert) {
+  var input = '<style>div#foo { background-color: red; color: white }</style>';
+  var output = '<style>div#foo { background-color: red; color: white } callback!</style>';
+  var done = assert.async();
+  assert.notOk(minify(
+    input,
+    {
+      minifyCSS: function(css, cb) {
+        setTimeout(function() {
+          cb(css + ' callback!');
+        }, 0);
+      }
+    },
+    function(result) {
+      assert.equal(result, output);
+      done();
+    }
+  ));
+});
+
+QUnit.test('script minification with callback', function(assert) {
+  var input = '<script>(function(){ console.log("Hello"); })()</script>';
+  var output = '<script>(function(){ console.log("Hello"); })()(function(){ console.log("World"); })()</script>';
+  var done = assert.async();
+  assert.notOk(minify(
+    input,
+    {
+      minifyJS: function(js, inline, cb) {
+        setTimeout(function() {
+          cb(js + '(function(){ console.log("World"); })()');
+        }, 0);
+      }
+    },
+    function(result) {
+      assert.equal(result, output);
+      done();
+    }
+  ));
+});

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -3411,7 +3411,8 @@ QUnit.test('style minification with callback', function(assert) {
         }, 0);
       }
     },
-    function(result) {
+    function(error, result) {
+      assert.notOk(error);
       assert.equal(result, output);
       done();
     }
@@ -3431,7 +3432,8 @@ QUnit.test('script minification with callback', function(assert) {
         }, 0);
       }
     },
-    function(result) {
+    function(error, result) {
+      assert.notOk(error);
       assert.equal(result, output);
       done();
     }
@@ -3452,7 +3454,8 @@ QUnit.test('style async minification with script sync minification', function(as
       },
       minifyJS: true
     },
-    function(result) {
+    function(error, result) {
+      assert.notOk(error);
       assert.equal(result, output);
       done();
     }
@@ -3473,7 +3476,8 @@ QUnit.test('style sync minification with script async minification', function(as
         }, 0);
       }
     },
-    function(result) {
+    function(error, result) {
+      assert.notOk(error);
       assert.equal(result, output);
       done();
     }
@@ -3498,7 +3502,8 @@ QUnit.test('style async minification with script async minification', function(a
         }, 0);
       }
     },
-    function(result) {
+    function(error, result) {
+      assert.notOk(error);
       assert.equal(result, output);
       done();
     }
@@ -3526,7 +3531,8 @@ QUnit.test('async minification along side sync minification', function(assert) {
         }, 0);
       }
     },
-    function(result) {
+    function(error, result) {
+      assert.notOk(error);
       assert.equal(result, asyncOutput);
       done();
     }
@@ -3557,7 +3563,8 @@ QUnit.test('multiple async minifications', function(assert) {
         }, 0);
       }
     },
-    function(result) {
+    function(error, result) {
+      assert.notOk(error);
       assert.equal(result, output);
       done();
     }
@@ -3577,7 +3584,8 @@ QUnit.test('multiple async minifications', function(assert) {
         }, 0);
       }
     },
-    function(result) {
+    function(error, result) {
+      assert.notOk(error);
       assert.equal(result, output);
       done();
     }
@@ -3591,9 +3599,44 @@ QUnit.test('sync minify with callback', function(assert) {
   assert.equal(minify(
     input,
     {},
-    function(result) {
+    function(error, result) {
+      assert.notOk(error);
       assert.equal(result, output);
       done();
     }
   ), output);
+});
+
+
+QUnit.test('minify error with callback', function(assert) {
+  var input = '<style>div#foo { background-color: red; }</style><invalid html';
+  var done = assert.async();
+
+  minify(
+    input,
+    {},
+    function(error) {
+      assert.ok(error);
+      done();
+    }
+  );
+});
+
+QUnit.test('error in callback', function(assert) {
+  var input = '<style>div#foo { background-color: red; }</style>';
+  var error = new Error();
+  var done = assert.async();
+
+  minify(
+    input,
+    {
+      minifyCSS: function() {
+        throw error;
+      }
+    },
+    function(err) {
+      assert.strictEqual(err, error);
+      done();
+    }
+  );
 });

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -3583,3 +3583,17 @@ QUnit.test('multiple async minifications', function(assert) {
     }
   ));
 });
+
+QUnit.test('sync minify with callback', function(assert) {
+  var input = '<html><head><title>Test</title></head><body>Hello World</body></html>';
+  var output = input;
+  var done = assert.async();
+  assert.equal(minify(
+    input,
+    {},
+    function(result) {
+      assert.equal(result, output);
+      done();
+    }
+  ), output);
+});


### PR DESCRIPTION
Adds callback support to `minify`, `minifyCSS` and `minifyJS` functions.
Does not break any existing functionality.

### Example Use:

```js
var minify = require('html-minifier').minify;
var html = '<html><head><style>body { margin: 0; display: flex; }</style></head></html>';

var config = {
  minifyCSS: function(css, cb) {
    doSomethingAsync(css, function(updatedCss) {
      cb(updatedCss);
    });
  },
  minifyJS: function(js, inline, cb) {
    doSomethingElseAsync(js, function(updatedJs) {
      cb(updatedJs);
    });
  }
};

minify(html, config, function(error, result) {
  if (error) {
    // Handle error.
  } else {
    // Do something with the results.
  }
});
```

Fixes #906