### PR TITLE
Function uniqueId always returns a 12 chars id

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -726,7 +726,9 @@ function processOptions(values) {
 function uniqueId(value) {
   var id;
   do {
-    id = Math.random().toString(36).replace(/^0\.[0-9]*/, '');
+    id = 'xxxxxxxxxxxx'.replace(/x/g, function () {
+      return (Math.random() * 16 | 0).toString(16);
+    });
   } while (~value.indexOf(id));
   return id;
 }


### PR DESCRIPTION
The function uniqueId was making this library "impure". The output of the minifier could be different from one call to another using the same input and using the option `maxLineLength`.

Let me explain: 

The function `joinResultSegments` is relying on the segments length to decide whether to add a newline separator or not when joining them while using the option `maxLineLength`. As the function `uniqueId` was generating a random length ID, sometimes you could have different outputs with HTML elements being moved to a new line while it wasn't on a previous call.

I changed the code of `uniqueId` a bit so that the returned ID is always a 12 chars string.
