### PR TITLE
Do not collapse boolean attributes with ignored values.

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -595,6 +595,7 @@ function buildAttr(normalized, hasUnarySlash, options, isLast, uidAttr) {
   }
 
   if (typeof attrValue === 'undefined' || options.collapseBooleanAttributes &&
+      !~attrValue.indexOf(uidAttr) &&
       isBooleanAttribute(attrName.toLowerCase(), attrValue.toLowerCase())) {
     attrFragment = attrName;
     if (!isLast) {

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -1432,6 +1432,13 @@ QUnit.test('collapsing boolean attributes', function(assert) {
     'Ismap Itemscope Loop Multiple Muted Nohref Noresize Noshade Novalidate Nowrap Open Pauseonexit Readonly ' +
     'Required Reversed Scoped Seamless Selected Sortable Truespeed Typemustmatch Visible></div>';
   assert.equal(minify(input, { collapseBooleanAttributes: true, caseSensitive: true }), output);
+
+  input = '<img src="test" readonly="readonly" disabled="${disabled}">';
+  assert.equal(minify(input, {
+    collapseBooleanAttributes: true,
+    removeAttributeQuotes: true,
+    ignoreCustomFragments: [/\$\{disabled\}/],
+  }), '<img src=test readonly disabled="${disabled}">');
 });
 
 QUnit.test('collapsing enumerated attributes', function(assert) {


### PR DESCRIPTION
When the value of a boolean attribute contains a value matching
ignoreCustomFragments we html-minifier should not remove the value even
if collapseBooleanAttributes is set.

Fixes #931