### PR TITLE
"html-minifier" (3.5.20) ignores input from STDIN even if no input files are specified on the command line

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -297,7 +297,7 @@ if (inputDir || outputDir) {
   processDirectory(inputDir, outputDir, fileExt);
 }
 // Minifying one or more files specified on the CMD line
-else if (content || content.length > 0) {
+else if (content) {
   writeMinify();
 }
 // Minifying input coming from STDIN

--- a/cli.js
+++ b/cli.js
@@ -297,7 +297,7 @@ if (inputDir || outputDir) {
   processDirectory(inputDir, outputDir, fileExt);
 }
 // Minifying one or more files specified on the CMD line
-else if (content !== '') {
+else if (content || content.length > 0) {
   writeMinify();
 }
 // Minifying input coming from STDIN

--- a/cli.js
+++ b/cli.js
@@ -297,7 +297,7 @@ if (inputDir || outputDir) {
   processDirectory(inputDir, outputDir, fileExt);
 }
 // Minifying one or more files specified on the CMD line
-else if (typeof content === 'string') {
+else if (content !== '') {
   writeMinify();
 }
 // Minifying input coming from STDIN


### PR DESCRIPTION
After upgrading HTMLMinifier to 3.5.20, "html-minifier" ignores input from STDIN even if no input files are specified on the command line. After doing some digging around, it looks like the recent changes to [Commander.js](https://github.com/tj/commander.js) (v2.17.X) have caused the issue; if there are no input files to read, an empty string is assigned to `content`, which is what ends up being minified instead of any input from STDIN.