### PR TITLE
"html-minifier" (3.5.20) ignores "--minify-urls" command-line option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -197,7 +197,7 @@ program.arguments('[files...]').action(function(files) {
 function createOptions() {
   var options = {};
   mainOptionKeys.forEach(function(key) {
-    var param = program[camelCase(key)];
+    var param = program[key === 'minifyURLs' ? 'minifyUrls' : camelCase(key)];
     if (typeof param !== 'undefined') {
       options[key] = param;
     }


### PR DESCRIPTION
After upgrading HTMLMinifier to 3.5.20, "html-minifier" ignores the `--minify-urls` command-line option:

```
$ echo '<a href="https://www.example.com/test/test.html">Test</a>' | node cli.js --minify-urls https://www.example.com/
<a href="https://www.example.com/test/test.html">Test</a>
```

It looks like the `camelCase` function incorrectly converts "minifyURLs" to "minifyU**r**Ls", causing the option to be ignored.