### PR TITLE
Omit `nomodule` attribute value as it's boolean

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -199,7 +199,7 @@ function isStyleSheet(tag, attrs) {
   return true;
 }
 
-var isSimpleBoolean = createMapFromString('allowfullscreen,async,autofocus,autoplay,checked,compact,controls,declare,default,defaultchecked,defaultmuted,defaultselected,defer,disabled,enabled,formnovalidate,hidden,indeterminate,inert,ismap,itemscope,loop,multiple,muted,nohref,noresize,noshade,novalidate,nowrap,open,pauseonexit,readonly,required,reversed,scoped,seamless,selected,sortable,truespeed,typemustmatch,visible');
+var isSimpleBoolean = createMapFromString('allowfullscreen,async,autofocus,autoplay,checked,compact,controls,declare,default,defaultchecked,defaultmuted,defaultselected,defer,disabled,enabled,formnovalidate,hidden,indeterminate,inert,ismap,itemscope,loop,multiple,muted,nohref,nomodule,noresize,noshade,novalidate,nowrap,open,pauseonexit,readonly,required,reversed,scoped,seamless,selected,sortable,truespeed,typemustmatch,visible');
 var isBooleanValue = createMapFromString('true,false');
 
 function isBooleanAttribute(attrName, attrValue) {


### PR DESCRIPTION
### Before

```js
const {minify} = require('html-minifier');

minify('<script nomodule="nomodule"></script>', {collapseBooleanAttributes: true});
//=> '<script nomodule="nomodule"></script>'
```

### After

```js
const {minify} = require('html-minifier');

minify('<script nomodule="nomodule"></script>', {collapseBooleanAttributes: true});
//=> '<script nomodule></script>'
```

------

ref. specification of `nomodule` attribute:  https://html.spec.whatwg.org/multipage/scripting.html#attr-script-nomodule
