### PR TITLE
Use <!doctypehtml> (without the space) where possible

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1235,7 +1235,9 @@ function minify(value, options, partialMarkup) {
       buffer.push(text);
     },
     doctype: function(doctype) {
-      buffer.push(options.useShortDoctype ? '<!doctype html>' : collapseWhitespaceAll(doctype));
+      buffer.push(options.useShortDoctype ? '<!doctype' +
+        (options.removeTagWhitespace ? '' : ' ') + 'html>' :
+        collapseWhitespaceAll(doctype));
     },
     customAttrAssign: options.customAttrAssign,
     customAttrSurround: options.customAttrSurround

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -410,6 +410,11 @@ QUnit.test('doctype normalization', function(assert) {
   assert.equal(minify(input, { useShortDoctype: false }), input);
   assert.equal(minify(input, { useShortDoctype: true }), output);
 
+  assert.equal(minify(input, {
+    useShortDoctype: true,
+    removeTagWhitespace: true
+  }), '<!doctypehtml>');
+
   input = '<!DOCTYPE\nhtml>';
   assert.equal(minify(input, { useShortDoctype: false }), '<!DOCTYPE html>');
   assert.equal(minify(input, { useShortDoctype: true }), output);


### PR DESCRIPTION
When both the `useShortDoctype` and the `removeTagWhitespace` options are enabled, we can remove the space from the doctype altogether.

It’s invalid HTML (which is already expected in the output with the `removeTagWhitespace` option enabled), but it still triggers standards mode.

https://html.spec.whatwg.org/multipage/parsing.html#parse-error-missing-whitespace-before-doctype-name
https://twitter.com/mathias/status/1048098677703753729

Closes #969.