### PR TITLE
added processScriptsFunction option

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -389,6 +389,11 @@ function processScript(text, options, currentAttrs) {
   for (var i = 0, len = currentAttrs.length; i < len; i++) {
     if (currentAttrs[i].name.toLowerCase() === 'type' &&
         options.processScripts.indexOf(currentAttrs[i].value) > -1) {
+
+      if(typeof options.processScriptsFunction === "function") {
+        return options.processScriptsFunction(text, currentAttrs[i].value)
+      }
+
       return minify(text, options);
     }
   }


### PR DESCRIPTION
Add ability to "processScripts" via a custom function. Useful for WebGL shaders and json-ld data.
For example, these options...

```javascript
const minifyOpt={
	"processScripts": [
		"application/ld+json",
		"x-shader/x-vertex",
		"x-shader/x-fragment"
	],
	"processScriptsFunction": function(text,script){
		if(script==="x-shader/x-vertex" || script==="x-shader/x-fragment"){
			// Strip comments + normalize whitespace (including line breaks)...
			return text.replace(/\/\*[\s\S]*?\*\/|\/\/.*/g,'').replace(/\s+/g,' ').trim();
		}else if(script==="application/ld+json"){
			// Strip whitespace
			return JSON.stringify(JSON.parse(text))
		}else return text;
	},
	"removeComments": true,
	"collapseWhitespace": true,
	"continueOnParseError": true
}
```
... could be used for this file...
```html
<!DOCTYPE html>
<html lang="en">
<head>
	<meta charset="UTF-8">
	<title>Minifier Test</title>
	<script id="vertexShader" type="x-shader/x-vertex">
		// Vertex shader with comments
		void main() {
			/**
 			 * Multi-line comments
 			 */
			gl_Position = projectionMatrix * modelViewMatrix * vec4(position.x+10.0, position.y, position.z+5.0, 1.0);
		}
	</script>
	<script id="fragmentShader" type="x-shader/x-fragment">
		// Fragment shader
		void main() {
			gl_FragColor = vec4(0.0, 0.58, 0.86, 1.0); // some more comments
		}
	</script>
	<script type="application/ld+json">
		{
			"@context": "http://schema.org",
			"@type": "WebPage",
			"name": "Lecture 12: Graphs, networks, incidence matrices",
			"description": "These video lectures of Professor Gilbert Strang teaching 18.06 were recorded in Fall 1999 and do not correspond precisely to the current  edition of the textbook.",
			"publisher": {
				"@type": "CollegeOrUniversity",
				"name": "MIT OpenCourseWare"
			},
			"license": "http://creativecommons.org/licenses/by-nc-sa/3.0/us/deed.en_US"
		}
	</script>
</head>
<body>

</body>
</html>
```
Currently the minifier breaks WebGL shaders if they have comments and does not remove all the white-space from json-ld scripts....
```html
<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>Minifier Test</title><script id="vertexShader" type="x-shader/x-vertex">// Vertex shader with comments void main() { /** * Multi-line comments */ gl_Position = projectionMatrix * modelViewMatrix * vec4(position.x+10.0, position.y, position.z+5.0, 1.0); }</script><script id="fragmentShader" type="x-shader/x-fragment">// Fragment shader void main() { gl_FragColor = vec4(0.0, 0.58, 0.86, 1.0); // some more comments }</script><script type="application/ld+json">{ "@context": "http://schema.org", "@type": "WebPage", "name": "Lecture 12: Graphs, networks, incidence matrices", "description": "These video lectures of Professor Gilbert Strang teaching 18.06 were recorded in Fall 1999 and do not correspond precisely to the current edition of the textbook.", "publisher": { "@type": "CollegeOrUniversity", "name": "MIT OpenCourseWare" }, "license": "http://creativecommons.org/licenses/by-nc-sa/3.0/us/deed.en_US" }</script></head><body></body></html>
```
... expected output (using the 'processScriptsFunction') ...
```html
<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>Minifier Test</title><script id="vertexShader" type="x-shader/x-vertex">void main() { gl_Position = projectionMatrix * modelViewMatrix * vec4(position.x+10.0, position.y, position.z+5.0, 1.0); }</script><script id="fragmentShader" type="x-shader/x-fragment">void main() { gl_FragColor = vec4(0.0, 0.58, 0.86, 1.0); }</script><script type="application/ld+json">{"@context":"http://schema.org","@type":"WebPage","name":"Lecture 12: Graphs, networks, incidence matrices","description":"These video lectures of Professor Gilbert Strang teaching 18.06 were recorded in Fall 1999 and do not correspond precisely to the current  edition of the textbook.","publisher":{"@type":"CollegeOrUniversity","name":"MIT OpenCourseWare"},"license":"http://creativecommons.org/licenses/by-nc-sa/3.0/us/deed.en_US"}</script></head><body></body></html>
```

