### PR TITLE
Fixing exceptions when attribute contains no value

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -183,11 +183,13 @@ function isExecutableScript(tag, attrs) {
 
 function isStyleLinkTypeAttribute(attrValue) {
   attrValue = trimWhitespace(attrValue);
-  if (!attrValue) {
-    return true;
+
+  if (typeof attrValue !== 'string') {
+    attrValue = '';
+  } else {
+    attrValue = attrValue.toLowerCase();
   }
   
-  attrValue = attrValue.toLowerCase();
   return attrValue === '' || attrValue === 'text/css';
 }
 

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -184,7 +184,7 @@ function isExecutableScript(tag, attrs) {
 function isStyleLinkTypeAttribute(attrValue) {
   attrValue = trimWhitespace(attrValue);
 
-  if (typeof attrValue !== 'string') {
+  if (typeof attrValue === 'undefined') {
     attrValue = '';
   } else {
     attrValue = attrValue.toLowerCase();

--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -182,7 +182,12 @@ function isExecutableScript(tag, attrs) {
 }
 
 function isStyleLinkTypeAttribute(attrValue) {
-  attrValue = trimWhitespace(attrValue).toLowerCase();
+  attrValue = trimWhitespace(attrValue);
+  if (!attrValue) {
+    return true;
+  }
+  
+  attrValue = attrValue.toLowerCase();
   return attrValue === '' || attrValue === 'text/css';
 }
 


### PR DESCRIPTION
This PR is to address the exception being thrown if the target html file contains `link` tags whose `type` attribute is defined but without a value. 

For example, when using the plugin with webpack, encountering the following `link` tag: 

`<link href="https://somecdn.com/favicon/favicon.png" rel="icon" type>` 

in a html file will crash the build process because of this exception: `TypeError: Cannot read property 'toLowerCase' of undefined`.

With this fix, we will treat the undefined attribute value as a blank string value, i.e. it will be equivalent as the `link` tag below:

`<link href="https://somecdn.com/favicon/favicon.png" rel="icon" type="">`.