### PR TITLE
Fix/update benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,19 @@ How does HTMLMinifier compare to other solutions — [HTML Minifier from Will Pe
 
 | Site                                                                         | Original size *(KB)* | HTMLMinifier | minimize | Will Peavy | htmlcompressor.com |
 | ---------------------------------------------------------------------------- |:--------------------:| ------------:| --------:| ----------:| ------------------:|
-| [Google](https://www.google.com/)                                            | 46                   | **42**       | 46       | 48         | 46                 |
-| [HTMLMinifier](https://github.com/kangax/html-minifier)                      | 125                  | **98**       | 111      | 117        | 111                |
-| [Twitter](https://twitter.com/)                                              | 207                  | **165**      | 200      | 224        | 200                |
-| [Stack Overflow](https://stackoverflow.com/)                                 | 253                  | **195**      | 207      | 215        | 204                |
-| [Bootstrap CSS](https://getbootstrap.com/docs/3.3/css/)                      | 271                  | **260**      | 269      | 228        | 269                |
-| [BBC](https://www.bbc.co.uk/)                                                | 298                  | **239**      | 290      | 291        | 280                |
-| [Amazon](https://www.amazon.co.uk/)                                          | 422                  | **316**      | 412      | 425        | n/a                |
-| [NBC](https://www.nbc.com/)                                                  | 553                  | **530**      | 552      | 553        | 534                |
-| [Wikipedia](https://en.wikipedia.org/wiki/President_of_the_United_States)    | 565                  | **461**      | 548      | 569        | 548                |
-| [New York Times](https://www.nytimes.com/)                                   | 678                  | **606**      | 675      | 670        | n/a                |
+| [Google](https://www.google.com/)                                            | 51                   | **45**       | 51       | 54         | 50                 |
+| [Stack Overflow](https://stackoverflow.com/)                                 | 203                  | **165**      | 178      | 179        | 173                |
+| [HTMLMinifier](https://github.com/kangax/html-minifier)                      | 237                  | **149**      | 215      | 230        | 216                |
+| [Bootstrap CSS](https://getbootstrap.com/docs/3.4/css/)                      | 303                  | **262**      | 272      | 241        | n/a                |
+| [BBC](https://www.bbc.co.uk/)                                                | 329                  | **306**      | 327      | 329        | n/a                |
+| [Amazon](https://www.amazon.co.uk/)                                          | 419                  | **377**      | 409      | 424        | n/a                |
+| [Twitter](https://twitter.com/)                                              | 482                  | **400**      | 474      | 531        | n/a                |
+| [Wikipedia](https://en.wikipedia.org/wiki/President_of_the_United_States)    | 696                  | **562**      | 675      | 701        | n/a                |
 | [Eloquent Javascript](https://eloquentjavascript.net/1st_edition/print.html) | 870                  | **815**      | 840      | 864        | n/a                |
-| [ES6 table](https://kangax.github.io/compat-table/es6/)                      | 5911                 | **5051**     | 5595     | n/a        | n/a                |
-| [ES draft](https://tc39.github.io/ecma262/)                                  | 6126                 | **5495**     | 5664     | n/a        | n/a                |
+| [New York Times](https://www.nytimes.com/)                                   | 1258                 | **1128**     | 1250     | 1225       | n/a                |
+| [NBC](https://www.nbc.com/)                                                  | 1982                 | **1822**     | 1968     | 1988       | n/a                |
+| [ES draft](https://tc39.github.io/ecma262/)                                  | 6041                 | **5310**     | 5502     | n/a        | n/a                |
+| [ES6 table](https://kangax.github.io/compat-table/es6/)                      | 8125                 | **6924**     | 7676     | n/a        | n/a                |
 
 ## Options Quick Reference
 

--- a/benchmark.js
+++ b/benchmark.js
@@ -297,7 +297,7 @@ run(fileNames.map(function(fileName) {
 
     function testWillPeavy(done) {
       readText(filePath, function(data) {
-        var options = url.parse('https://www.willpeavy.com/minifier/');
+        var options = url.parse('https://www.willpeavy.com/tools/minifier/');
         options.method = 'POST';
         options.headers = {
           'Content-Type': 'application/x-www-form-urlencoded'
@@ -335,7 +335,7 @@ run(fileNames.map(function(fileName) {
 
     function testHTMLCompressor(done) {
       readText(filePath, function(data) {
-        var options = url.parse('https://htmlcompressor.com/compress_ajax_v2.php');
+        var options = url.parse('https://htmlcompressor.com/compress');
         options.method = 'POST';
         options.headers = {
           'Accept-Encoding': 'gzip',

--- a/benchmark.js
+++ b/benchmark.js
@@ -206,6 +206,7 @@ function displayTable() {
 
 run(fileNames.map(function(fileName) {
   var filePath = path.join('benchmarks/', fileName + '.html');
+  fs.mkdirSync('benchmarks/generated/', { recursive: true });
 
   function processFile(site, done) {
     var original = {

--- a/benchmark.js
+++ b/benchmark.js
@@ -119,9 +119,10 @@ function readSize(filePath, callback) {
 }
 
 function gzip(inPath, outPath, callback) {
-  fs.createReadStream(inPath).pipe(zlib.createGzip({
-    level: zlib.Z_BEST_COMPRESSION
-  })).pipe(fs.createWriteStream(outPath)).on('finish', callback);
+  fs.createReadStream(inPath)
+    .pipe(zlib.createGzip())
+    .pipe(fs.createWriteStream(outPath))
+    .on('finish', callback);
 }
 
 function brotli(inPath, outPath, callback) {

--- a/benchmark.js
+++ b/benchmark.js
@@ -382,6 +382,7 @@ run(fileNames.map(function(fileName) {
           });
         }).on('error', failed).end(querystring.stringify({
           code_type: 'html',
+          output_format: 'json',
           html_level: 3,
           html_strip_quotes: 1,
           minimize_style: 1,

--- a/benchmark.js
+++ b/benchmark.js
@@ -240,7 +240,7 @@ run(fileNames.map(function(fileName) {
               if (error) {
                 throw error;
               }
-              writeBuffer(info.lzFilePath, new Buffer(result), function() {
+              writeBuffer(info.lzFilePath, Buffer.from(result), function() {
                 info.lzTime = Date.now();
                 // Open and read the size of the minified+lzma output
                 readSize(info.lzFilePath, function(size) {
@@ -254,7 +254,7 @@ run(fileNames.map(function(fileName) {
         // Apply Brotli on minified output
         function(done) {
           readBuffer(info.filePath, function(data) {
-            var output = new Buffer(brotli.compress(data, true).buffer);
+            var output = Buffer.from(brotli.compress(data, true).buffer);
             writeBuffer(info.brFilePath, output, function() {
               info.brTime = Date.now();
               // Open and read the size of the minified+brotli output

--- a/benchmarks/index.json
+++ b/benchmarks/index.json
@@ -1,7 +1,7 @@
 {
   "Amazon": "https://www.amazon.co.uk/",
   "BBC": "https://www.bbc.co.uk/",
-  "Bootstrap CSS": "https://getbootstrap.com/docs/3.3/css/",
+  "Bootstrap CSS": "https://getbootstrap.com/docs/3.4/css/",
   "Eloquent Javascript": "https://eloquentjavascript.net/1st_edition/print.html",
   "ES draft": "https://tc39.github.io/ecma262/",
   "ES6 table": "https://kangax.github.io/compat-table/es6/",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "qunit": "^2.17.2"
   },
   "benchmarkDependencies": {
-    "brotli": "^1.3.2",
     "chalk": "^4.1.2",
     "cli-table": "^0.3.6",
     "lzma": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
   "benchmarkDependencies": {
     "chalk": "^4.1.2",
     "cli-table": "^0.3.6",
-    "lzma": "^2.3.2",
     "minimize": "^2.2.0",
     "progress": "^2.0.3"
   },


### PR DESCRIPTION
`htmlcompressor.com` has an upper limit of ~300KB hence why it fails. We could probably just drop it later.

Also, IMHO we should move the benchmark script into the benchmark folder along with its own package.json and run it on CI (probably with a cron job since we don't want it to run all the time). Otherwise it can break at any time again.