### PR TITLE
useShortDoctype: always add a space after `doctype`

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -1255,9 +1255,11 @@ function minify(value, options, partialMarkup) {
       buffer.push(text);
     },
     doctype: function(doctype) {
-      buffer.push(options.useShortDoctype ? '<!doctype' +
-        (options.removeTagWhitespace ? '' : ' ') + 'html>' :
-        collapseWhitespaceAll(doctype));
+      buffer.push(
+        options.useShortDoctype ?
+          '<!doctype html>' :
+          collapseWhitespaceAll(doctype)
+      );
     }
   });
 

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -431,7 +431,7 @@ QUnit.test('doctype normalization', function(assert) {
   assert.equal(minify(input, {
     useShortDoctype: true,
     removeTagWhitespace: true
-  }), '<!doctypehtml>');
+  }), '<!doctype html>');
 
   input = '<!DOCTYPE\nhtml>';
   assert.equal(minify(input, { useShortDoctype: false }), '<!DOCTYPE html>');


### PR DESCRIPTION
Fixes #1053 

IMHO removing this one space isn't worth it compared to outputting valid HTML.