### PR TITLE
Update remaining major dependencies

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -27,13 +27,15 @@
 
 'use strict';
 
-var camelCase = require('camel-case');
+var camelCase = require('camel-case').camelCase;
 var fs = require('fs');
 var info = require('./package.json');
 var minify = require('./' + info.main).minify;
-var paramCase = require('param-case');
+var paramCase = require('param-case').paramCase;
 var path = require('path');
-var program = require('commander');
+var command = require('commander').Command;
+var program = new command();
+var programOptions = program.opts();
 
 program._name = info.name;
 program.version(info.version);
@@ -41,6 +43,12 @@ program.version(info.version);
 function fatal(message) {
   console.error(message);
   process.exit(1);
+}
+
+// If no argument has been specified on the command line, show help message and exit
+if (!process.argv.slice(2).length) {
+  program.outputHelp();
+  process.exit();
 }
 
 /**
@@ -198,7 +206,7 @@ program.arguments('[files...]').action(function(files) {
 function createOptions() {
   var options = {};
   mainOptionKeys.forEach(function(key) {
-    var param = program[key === 'minifyURLs' ? 'minifyUrls' : camelCase(key)];
+    var param = programOptions[key === 'minifyURLs' ? 'minifyUrls' : camelCase(key)];
     if (typeof param !== 'undefined') {
       options[key] = param;
     }
@@ -280,14 +288,14 @@ function writeMinify() {
   catch (e) {
     fatal('Minification error:\n' + e.message);
   }
-  (program.output ? fs.createWriteStream(program.output).on('error', function(e) {
-    fatal('Cannot write ' + program.output + '\n' + e.message);
+  (programOptions.output ? fs.createWriteStream(programOptions.output).on('error', function(e) {
+    fatal('Cannot write ' + programOptions.output + '\n' + e.message);
   }) : process.stdout).write(minified);
 }
 
-var inputDir = program.inputDir;
-var outputDir = program.outputDir;
-var fileExt = program.fileExt;
+var inputDir = programOptions.inputDir;
+var outputDir = programOptions.outputDir;
+var fileExt = programOptions.fileExt;
 if (inputDir || outputDir) {
   if (!inputDir) {
     fatal('The option output-dir needs to be used with the option input-dir. If you are working with a single file, use -o.');

--- a/package-lock.json
+++ b/package-lock.json
@@ -660,12 +660,12 @@
       "dev": true
     },
     "camel-case": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.1"
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
       }
     },
     "caseless": {
@@ -769,9 +769,9 @@
       }
     },
     "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1030,6 +1030,34 @@
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
+    },
+    "dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "lower-case": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+          "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+          "requires": {
+            "tslib": "^2.0.3"
+          }
+        },
+        "no-case": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+          "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+          "requires": {
+            "lower-case": "^2.0.2",
+            "tslib": "^2.0.3"
+          }
+        }
+      }
     },
     "duplexer": {
       "version": "0.1.2",
@@ -2629,9 +2657,12 @@
       "dev": true
     },
     "lower-case": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "requires": {
+        "tslib": "^2.0.3"
+      }
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -2825,11 +2856,12 @@
       "dev": true
     },
     "no-case": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
       "requires": {
-        "lower-case": "^1.1.1"
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
       }
     },
     "node-watch": {
@@ -2993,11 +3025,12 @@
       "dev": true
     },
     "param-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
-      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
       "requires": {
-        "no-case": "^2.2.0"
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "parent-module": {
@@ -3047,6 +3080,15 @@
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
+    },
+    "pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
     },
     "path-browserify": {
       "version": "1.0.1",
@@ -3852,6 +3894,11 @@
         }
       }
     },
+    "tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
     "tty-browserify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
@@ -3945,11 +3992,6 @@
         "sprintf-js": "^1.0.3",
         "util-deprecate": "^1.0.2"
       }
-    },
-    "upper-case": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -54,11 +54,11 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "camel-case": "^3.0.0",
+    "camel-case": "^4.1.2",
     "clean-css": "^5.2.1",
-    "commander": "^2.20.3",
+    "commander": "^7.2.0",
     "he": "^1.2.0",
-    "param-case": "^2.1.1",
+    "param-case": "^3.0.4",
     "relateurl": "^0.2.7",
     "uglify-js": "^3.14.2"
   },


### PR DESCRIPTION
Resolves #1111 by updating `camel-case`, `commander` and `param-case`. Apparently also closes #985.

Also makes the CLI output a help message instead of running forever (which is the current behaviour) when no argument has been specified.